### PR TITLE
fix(ci): grant OIDC/attestation permissions for docker provenance

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,6 +31,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write       # Required for OIDC token (attestation)
+      attestations: write   # Required for provenance upload
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission for OIDC token request
- Add `attestations: write` permission for provenance upload

These permissions are required by `actions/attest-build-provenance@v3` to generate artifact attestation.

## Problem

Tagged releases were failing at the attestation step with:
```
Error: missing ACTIONS_ID_TOKEN_REQUEST_URL
```

This occurred because the job lacked the permissions needed for OIDC token generation.

## Test plan

- [ ] PR build completes (build-only, no push/attestation)
- [ ] After merge, create test tag `v1.9.1` to verify attestation succeeds