### PR TITLE
ci: make caches best-effort; stop caching .venv

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -43,21 +43,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache HuggingFace models
-        uses: actions/cache@v5
+      - name: Restore HuggingFace cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/huggingface
-          key: hf-models-${{ hashFiles('pyproject.toml') }}
+          key: hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            hf-models-
+            hf-${{ runner.os }}-
 
-      - name: Cache uv
-        uses: actions/cache@v5
+      - name: Restore uv cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            .venv
-            .cache/uv
-          key: uv-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-
 
@@ -75,6 +73,22 @@ jobs:
       - name: Run CI (fast mode)
         run: nix run .#ci -- fast
 
+      - name: Save HuggingFace cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Save uv cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+
   # Full CI suite (complete)
   nix-ci-full:
     name: Nix CI (full)
@@ -87,21 +101,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache HuggingFace models
-        uses: actions/cache@v5
+      - name: Restore HuggingFace cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/huggingface
-          key: hf-models-${{ hashFiles('pyproject.toml') }}
+          key: hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            hf-models-
+            hf-${{ runner.os }}-
 
-      - name: Cache uv
-        uses: actions/cache@v5
+      - name: Restore uv cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            .venv
-            .cache/uv
-          key: uv-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
             uv-${{ runner.os }}-
 
@@ -118,3 +130,19 @@ jobs:
 
       - name: Run CI (full suite)
         run: nix run .#ci -- full
+
+      - name: Save HuggingFace cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Save uv cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,13 +169,13 @@ jobs:
       - name: Install test dependencies
         run: uv pip install pytest pytest-mock
 
-      - name: Cache HuggingFace models
-        uses: actions/cache@v5
+      - name: Restore HuggingFace cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/huggingface
-          key: ${{ runner.os }}-huggingface-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+          key: hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            ${{ runner.os }}-huggingface-
+            hf-${{ runner.os }}-
 
       - name: Run heavy tests
         run: |
@@ -184,6 +184,14 @@ jobs:
             -m "heavy" \
             --tb=short
         continue-on-error: true  # Don't fail CI if heavy tests fail
+
+      - name: Save HuggingFace cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
 
   test-integration:
     name: Integration tests

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -24,15 +24,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache uv
-        uses: actions/cache@v5
+      - name: Restore uv cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            .venv
-            .cache/uv
-          key: verify-uv-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
-            verify-uv-${{ runner.os }}-
+            uv-${{ runner.os }}-
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -48,6 +46,14 @@ jobs:
       - name: Run verification (quick)
         run: nix run .#verify -- --quick
 
+      - name: Save uv cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+
   verify-full:
     name: Verify (full)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -60,23 +66,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache uv
-        uses: actions/cache@v5
+      - name: Restore uv cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            .venv
-            .cache/uv
-          key: verify-uv-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
-            verify-uv-${{ runner.os }}-
+            uv-${{ runner.os }}-
 
-      - name: Cache HuggingFace models
-        uses: actions/cache@v5
+      - name: Restore HuggingFace cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/huggingface
-          key: hf-models-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+          key: hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
-            hf-models-${{ runner.os }}-
+            hf-${{ runner.os }}-
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -95,6 +99,22 @@ jobs:
       - name: Run verification (full)
         run: nix develop .# --command uv run slower-whisper-verify
 
+      - name: Save uv cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+
+      - name: Save HuggingFace cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
   verify-api:
     name: Verify (API surface)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -105,15 +125,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache uv
-        uses: actions/cache@v5
+      - name: Restore uv cache
+        uses: actions/cache/restore@v4
         with:
-          path: |
-            .venv
-            .cache/uv
-          key: verify-uv-${{ runner.os }}-${{ hashFiles('pyproject.toml', 'uv.lock') }}
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
-            verify-uv-${{ runner.os }}-
+            uv-${{ runner.os }}-
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31
@@ -131,3 +149,11 @@ jobs:
 
       - name: Run API verification
         run: nix develop .# --command uv run slower-whisper-verify --api
+
+      - name: Save uv cache
+        if: always()
+        continue-on-error: true
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}


### PR DESCRIPTION
## Summary

- Replace implicit cache action with explicit restore/save pattern
- Add `continue-on-error: true` to cache saves (non-fatal)
- Cache only `~/.cache/uv` and `~/.cache/huggingface` (not `.venv`)
- Standardize cache keys across workflows
- Use `actions/cache@v4` (stable release line)

## Why

The Verify workflow was failing with tar errors during cache save. This was caused by:
1. Caching `.venv` which can have permission/symlink issues
2. Cache save failures being fatal to the job

With this change, cache operations are purely an optimization - failures don't break CI.

## Cache Key Scheme

| Cache | Key Pattern |
|-------|-------------|
| uv | `uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}` |
| HuggingFace | `hf-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}` |

## Test Plan

- [ ] Verify quick job passes
- [ ] Confirm no cache-related failures in job logs