### PR TITLE
chore(release): v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [1.9.1] - 2026-01-05
+
+### Changed
+
+- **GPU UX**: `--device auto` is now the default; preflight banner emits GPU/CPU status to stderr; compute_type fallback is safer on CPU-only systems
+- **Documentation**: New `docs/GPU_SETUP.md` guide for GPU configuration
+
+### Fixed
+
+- **CI caching**: Cache saves are now best-effort; removed `.venv` tar flake that caused spurious CI failures
+- **Docker attestations**: Fixed OIDC permissions for provenance attestation on tag builds (#113)
+
 ## [1.9.0] - 2025-12-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slower-whisper"
-version = "1.9.0"
+version = "1.9.1"
 description = "Local-first conversation signal engine: transform audio into LLM-ready structured data with speaker diarization, prosody, and emotion"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"


### PR DESCRIPTION
## Summary

Version bump for v1.9.1 patch release.

**Changes since v1.9.0:**
- GPU UX: `--device auto` default, preflight banner to stderr, safe compute_type fallback
- Docs: `docs/GPU_SETUP.md`
- CI: best-effort caches (no `.venv` tar flake)
- Docker: OIDC + attestations permissions (#113); tag builds produce provenance

## After merge

```bash
git switch main && git pull --ff-only
git tag -a v1.9.1 -m "v1.9.1"
git push origin v1.9.1
```