### PR TITLE
chore(release): v1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _No unreleased changes._
 
+## [1.9.2] - 2026-01-05
+
+### Fixed
+
+- **Version constant mismatch**: Fixed `transcription.__version__` reporting `"1.9.0"` instead of matching the package version. The runtime version constant now correctly reports `"1.9.2"`.
+
 ## [1.9.1] - 2026-01-05
 
 ### Changed
@@ -731,5 +737,19 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
 - [Issue Tracker](https://github.com/EffortlessMetrics/slower-whisper/issues)
 - [Releases](https://github.com/EffortlessMetrics/slower-whisper/releases)
 
-[1.0.0]: https://github.com/EffortlessMetrics/slower-whisper/releases/tag/v1.0.0
+[Unreleased]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.9.2...HEAD
+[1.9.2]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.9.1...v1.9.2
+[1.9.1]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.9.0...v1.9.1
+[1.9.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.7.1...v1.8.0
+[1.7.1]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.7.0...v1.7.1
+[1.7.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.3.1...v1.4.0
+[1.3.1]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/EffortlessMetrics/slower-whisper/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/EffortlessMetrics/slower-whisper/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "slower-whisper"
-version = "1.9.1"
+version = "1.9.2"
 description = "Local-first conversation signal engine: transform audio into LLM-ready structured data with speaker diarization, prosody, and emotion"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/transcription/__init__.py
+++ b/transcription/__init__.py
@@ -58,7 +58,7 @@ from typing import Any
 
 # Version of the transcription pipeline; included in JSON metadata.
 # Must be defined before other imports to avoid circular imports
-__version__ = "1.9.0"
+__version__ = "1.9.2"
 
 # Configure global cache environment for all model downloads
 # This ensures all HF/torch models are cached under SLOWER_WHISPER_CACHE_ROOT


### PR DESCRIPTION
## Summary

- Fix version reporting: v1.9.1 self-reported 1.9.0 at runtime; v1.9.2 fixes this

## Test plan

- [x] All fast gate checks pass (pre-commit, mypy, pytest, verify)
- [ ] CI passes
- [ ] After merge, tag v1.9.2 and verify docker-build workflow succeeds