### PR TITLE
chore(version): single-source __version__ + guardrail test

### DIFF
--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,34 @@
+# tests/test_versioning.py
+"""Guardrail test to prevent version sync issues like v1.9.1."""
+
+from __future__ import annotations
+
+import importlib.metadata as md
+
+import pytest
+
+import transcription
+
+
+def test_runtime_version_matches_package_metadata() -> None:
+    """Ensure runtime __version__ matches installed package metadata.
+
+    This test prevents regressions where a hardcoded version constant
+    could drift from pyproject.toml. When the package is installed,
+    both must report the same version.
+    """
+    try:
+        expected = md.version("slower-whisper")
+    except md.PackageNotFoundError:
+        pytest.skip("slower-whisper not installed in this environment")
+    assert transcription.__version__ == expected
+
+
+def test_version_is_not_dev_when_installed() -> None:
+    """Ensure we don't accidentally ship with dev version string."""
+    try:
+        _ = md.version("slower-whisper")
+    except md.PackageNotFoundError:
+        pytest.skip("slower-whisper not installed in this environment")
+    # If package is installed, version should not be the fallback
+    assert transcription.__version__ != "0.0.0-dev"

--- a/transcription/__init__.py
+++ b/transcription/__init__.py
@@ -54,15 +54,15 @@ Exceptions:
     - ConfigurationError: Raised when configuration is invalid
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from typing import Any
 
 # Version of the transcription pipeline; included in JSON metadata.
 # Single-sourced from pyproject.toml via importlib.metadata
 try:
-    from importlib.metadata import version
-
-    __version__ = version("slower-whisper")
-except Exception:
+    __version__ = _pkg_version("slower-whisper")
+except PackageNotFoundError:
     __version__ = "0.0.0-dev"
 
 # Configure global cache environment for all model downloads
@@ -120,7 +120,7 @@ from .models import (
 )
 from .semantic import KeywordSemanticAnnotator, NoOpSemanticAnnotator, SemanticAnnotator
 from .speaker_id import get_speaker_id, get_speaker_label_or_id
-from .streaming import StreamChunk, StreamConfig, StreamEvent, StreamEventType, StreamingSession
+from .streaming import StreamChunk, StreamConfig, StreamEvent, StreamingSession
 
 # v1.9.0 streaming callbacks
 from .streaming_callbacks import StreamCallbacks, StreamingError


### PR DESCRIPTION
## Summary
- Single-source `__version__` from `pyproject.toml` via `importlib.metadata`
- Tighten exception handling to use specific `PackageNotFoundError` instead of generic `Exception`
- Add `tests/test_versioning.py` guardrail to prevent version sync drift

## Changes
- `transcription/__init__.py`: Use `importlib.metadata.version()` with proper error handling
- `tests/test_versioning.py`: New test file to verify version consistency

## Test plan
- [x] `pytest tests/test_versioning.py` passes
- [x] `ruff check` passes
- [x] `mypy` passes
- [ ] CI passes