### PR TITLE
fix(nix): source package version from pyproject.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,10 @@
           let pkg = unstablePkgs.ruff; in
           assert (pkg.version == "0.14.9"); pkg;
 
+        # Extract version from pyproject.toml (single source of truth)
+        pyprojectToml = builtins.fromTOML (builtins.readFile ./pyproject.toml);
+        packageVersion = pyprojectToml.project.version;
+
         runtimeBinPath = pkgs.lib.makeBinPath [ pkgs.uv pkgs.ffmpeg ];
         # Runtime libs for Python wheels (numpy, torch, etc. need libstdc++)
         # Note: This breaks nix commands when run from within the devshell because
@@ -335,7 +339,7 @@
         # Default package (minimal, for nix build)
         packages.default = pkgs.python312Packages.buildPythonPackage {
           pname = "slower-whisper";
-          version = "1.3.0";
+          version = packageVersion;  # Sourced from pyproject.toml
           src = ./.;
 
           propagatedBuildInputs = systemDeps;


### PR DESCRIPTION
## Summary

- Fix Nix package version drift by dynamically sourcing version from `pyproject.toml`
- Replace hardcoded `version = "1.3.0"` with `builtins.fromTOML` extraction

## Changes

1. Added `pyprojectToml` and `packageVersion` bindings at flake scope (lines 19-21)
2. Changed `packages.default` version from `"1.3.0"` to `packageVersion` (line 342)

## Verification

```bash
# Clean environment (avoid libstdc++ ABI conflict)
env -u LD_LIBRARY_PATH nix eval .#packages.x86_64-linux.default.version
# Output: "1.9.2"

# Flake check passes
env -u LD_LIBRARY_PATH nix flake check --no-build
```

## Test plan

- [x] `nix eval .#packages.x86_64-linux.default.version` returns correct version
- [x] `nix flake check --no-build` passes
- [x] Pre-commit hooks pass

Fixes #79