### PR TITLE
build: make the installed distribution complete and verifiable

### DIFF
--- a/.github/workflows/artifact-integrity.yml
+++ b/.github/workflows/artifact-integrity.yml
@@ -71,6 +71,7 @@ jobs:
           "$ARTIFACT_VENV/bin/slower-whisper" enrich --help
           "$ARTIFACT_VENV/bin/slower-whisper" benchmark --help
           "$ARTIFACT_VENV/bin/slower-whisper" validate --help
+          "$ARTIFACT_VENV/bin/slower-whisper-dogfood" --help
 
           "$ARTIFACT_VENV/bin/python" - <<'PY'
           from __future__ import annotations

--- a/.github/workflows/artifact-integrity.yml
+++ b/.github/workflows/artifact-integrity.yml
@@ -81,6 +81,12 @@ jobs:
           import json
           from pathlib import Path
 
+          def module_available(name: str) -> bool:
+              try:
+                  return importlib.util.find_spec(name) is not None
+              except ModuleNotFoundError:
+                  return False
+
           modules = [
               "slower_whisper",
               "transcription",
@@ -117,10 +123,10 @@ jobs:
           transcript_schema = package_root.joinpath("schemas/transcript-v2.schema.json")
           json.loads(transcript_schema.read_text(encoding="utf-8"))
 
-          assert importlib.util.find_spec("scripts.verify_all") is None, (
+          assert not module_available("scripts.verify_all"), (
               "repository verifier leaked into the installed product"
           )
-          assert importlib.util.find_spec("transcription.historian") is None, (
+          assert not module_available("transcription.historian"), (
               "PR historian leaked into the installed product"
           )
           PY

--- a/.github/workflows/artifact-integrity.yml
+++ b/.github/workflows/artifact-integrity.yml
@@ -1,0 +1,139 @@
+name: Artifact Integrity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  artifact-installed:
+    name: artifact-installed (${{ matrix.artifact }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact: [wheel, sdist]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Build distribution artifacts
+        run: |
+          uv build
+          uvx twine check dist/*
+
+      - name: Install selected artifact in a clean environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          VENV="$RUNNER_TEMP/slower-whisper-${{ matrix.artifact }}"
+          uv venv "$VENV" --python 3.12
+
+          if [[ "${{ matrix.artifact }}" == "wheel" ]]; then
+            TARGET=$(find dist -maxdepth 1 -name '*.whl' -print -quit)
+          else
+            TARGET=$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)
+          fi
+
+          test -n "$TARGET"
+          uv pip install --python "$VENV/bin/python" "$TARGET"
+          uv pip check --python "$VENV/bin/python"
+          echo "ARTIFACT_VENV=$VENV" >> "$GITHUB_ENV"
+
+      - name: Exercise installed console and import surfaces outside checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          unset PYTHONPATH
+
+          "$ARTIFACT_VENV/bin/slower-whisper" --version
+          "$ARTIFACT_VENV/bin/slower-whisper" --help
+          "$ARTIFACT_VENV/bin/slower-whisper" transcribe --help
+          "$ARTIFACT_VENV/bin/slower-whisper" enrich --help
+          "$ARTIFACT_VENV/bin/slower-whisper" benchmark --help
+          "$ARTIFACT_VENV/bin/slower-whisper" validate --help
+
+          "$ARTIFACT_VENV/bin/python" - <<'PY'
+          from __future__ import annotations
+
+          import importlib
+          import importlib.resources
+          import importlib.util
+          import json
+          from pathlib import Path
+
+          modules = [
+              "slower_whisper",
+              "transcription",
+              "transcription.cli",
+              "transcription.benchmark",
+              "transcription.cli_commands",
+              "transcription.integrations",
+              "transcription.semantic_providers",
+              "transcription.store",
+          ]
+
+          for name in modules:
+              module = importlib.import_module(name)
+              module_file = getattr(module, "__file__", None)
+              if module_file is not None:
+                  path = Path(module_file).resolve()
+                  assert "site-packages" in path.parts, (
+                      f"{name} imported outside site-packages: {path}"
+                  )
+              print(f"imported {name}")
+
+          package_root = importlib.resources.files("transcription")
+          required_resources = [
+              "schemas/transcript-v2.schema.json",
+              "schemas/stream_event.schema.json",
+              "schemas/README.md",
+              "py.typed",
+          ]
+          for relative_path in required_resources:
+              resource = package_root.joinpath(relative_path)
+              assert resource.is_file(), f"missing installed resource: {relative_path}"
+              print(f"found {relative_path}")
+
+          transcript_schema = package_root.joinpath("schemas/transcript-v2.schema.json")
+          json.loads(transcript_schema.read_text(encoding="utf-8"))
+
+          assert importlib.util.find_spec("scripts.verify_all") is None, (
+              "repository verifier leaked into the installed product"
+          )
+          assert importlib.util.find_spec("transcription.historian") is None, (
+              "PR historian leaked into the installed product"
+          )
+          PY
+
+      - name: Inspect wheel contents
+        if: matrix.artifact == 'wheel'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m zipfile -l dist/*.whl | tee "$RUNNER_TEMP/wheel-contents.txt"
+          grep -q 'transcription/cli_commands/' "$RUNNER_TEMP/wheel-contents.txt"
+          grep -q 'transcription/store/' "$RUNNER_TEMP/wheel-contents.txt"
+          grep -q 'transcription/benchmark/' "$RUNNER_TEMP/wheel-contents.txt"
+          grep -q 'transcription/schemas/transcript-v2.schema.json' "$RUNNER_TEMP/wheel-contents.txt"
+          ! grep -q 'transcription/historian/' "$RUNNER_TEMP/wheel-contents.txt"
+          ! grep -q 'scripts/verify_all.py' "$RUNNER_TEMP/wheel-contents.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,6 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -182,7 +181,7 @@ jobs:
       - name: Install wheel in clean environment
         run: |
           uv venv .venv-smoke
-          uv pip install --python .venv-smoke dist/*.whl
+          .venv-smoke/bin/pip install dist/*.whl
 
       - name: Verify slower_whisper import (installed wheel)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -181,7 +182,7 @@ jobs:
       - name: Install wheel in clean environment
         run: |
           uv venv .venv-smoke
-          .venv-smoke/bin/pip install dist/*.whl
+          uv pip install --python .venv-smoke dist/*.whl
 
       - name: Verify slower_whisper import (installed wheel)
         run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,4 +1,4 @@
-name: Verify (slower-whisper-verify)
+name: Verify (repository)
 
 on:
   pull_request:
@@ -97,7 +97,7 @@ jobs:
         run: nix develop .# --command uv sync --extra full --extra diarization --extra dev
 
       - name: Run verification (full)
-        run: nix develop .# --command uv run slower-whisper-verify
+        run: nix develop .# --command uv run python scripts/verify_all.py
 
       - name: Save uv cache
         if: always()
@@ -148,7 +148,7 @@ jobs:
         run: nix develop .# --command uv sync --extra api --extra dev
 
       - name: Run API verification
-        run: nix develop .# --command uv run slower-whisper-verify --api
+        run: nix develop .# --command uv run python scripts/verify_all.py --api
 
       - name: Save uv cache
         if: always()

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,15 +30,10 @@ include requirements-base.txt
 include requirements-enrich.txt
 include requirements-dev.txt
 
-# Typed package markers
+# Runtime package data
 include transcription/py.typed
 include slower_whisper/py.typed
-
-# Docs and examples
-
-# Benchmarks and tests
-
-# Operational/deployment assets
+recursive-include transcription/schemas *.json *.md
 
 # Exclude compiled/temporary artifacts
 global-exclude __pycache__
@@ -67,7 +62,7 @@ prune input_audio
 prune transcripts
 prune whisper_json
 
-# Exclude virtual environments
+# Exclude virtual environments and repository-only surfaces
 prune venv
 prune env
 prune .venv
@@ -78,3 +73,6 @@ prune .github
 prune benchmarks
 prune examples
 prune docs
+prune scripts
+prune integrations
+prune transcription/historian

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -35,18 +35,10 @@ include transcription/py.typed
 include slower_whisper/py.typed
 
 # Docs and examples
-recursive-include docs *.md *.txt *.json *.py
-recursive-include examples *.py *.md *.json *.txt
 
 # Benchmarks and tests
-recursive-include benchmarks *.py *.md *.json *.jsonl *.txt *.csv *.wav *.rttm
-recursive-include tests *.py *.json *.wav *.feature
 
 # Operational/deployment assets
-recursive-include scripts *.py *.sh *.md
-recursive-include config *
-recursive-include k8s *
-recursive-include .github *.yml *.yaml *.md
 
 # Exclude compiled/temporary artifacts
 global-exclude __pycache__
@@ -79,3 +71,10 @@ prune whisper_json
 prune venv
 prune env
 prune .venv
+prune tests
+prune config
+prune k8s
+prune .github
+prune benchmarks
+prune examples
+prune docs

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ verify-quick:
 	@echo "Running quick verification..."
 	@echo "This verifies: code quality + tests + BDD + API BDD"
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	uv run slower-whisper-verify --quick
+	uv run python scripts/verify_all.py --quick
 
 # Full verification (recommended before PRs)
 verify:
@@ -35,7 +35,7 @@ verify:
 	@echo "Running full verification..."
 	@echo "This includes: Docker builds + K8s validation"
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	uv run slower-whisper-verify
+	uv run python scripts/verify_all.py
 
 # Development commands
 test:

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -70,6 +70,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY transcription/ ./transcription/
 COPY scripts/ ./scripts/
 COPY integrations/ ./integrations/
+COPY slower_whisper/ ./slower_whisper/
 
 # Install Python dependencies using uv
 # ARG INSTALL_MODE controls which dependencies to install

--- a/config/Dockerfile.gpu
+++ b/config/Dockerfile.gpu
@@ -91,6 +91,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY transcription/ ./transcription/
 COPY scripts/ ./scripts/
 COPY integrations/ ./integrations/
+COPY slower_whisper/ ./slower_whisper/
 
 # Install Python dependencies using uv
 # ARG INSTALL_MODE controls which dependencies to install

--- a/flake.nix
+++ b/flake.nix
@@ -273,8 +273,8 @@
 
                 # Check 8: Verify (requires HF_TOKEN for diarization models)
                 if [ -n "''${HF_TOKEN:-}" ]; then
-                  run_check "Verification suite (slower-whisper-verify --quick)" \
-                    ${pkgs.uv}/bin/uv run slower-whisper-verify --quick
+                  run_check "Verification suite (scripts/verify_all.py --quick)" \
+                    ${pkgs.uv}/bin/uv run python scripts/verify_all.py --quick
                 else
                   echo -e "''${YELLOW}⚠ Skipping verify: HF_TOKEN not set''${NC}"
                   echo ""
@@ -319,7 +319,7 @@
             '');
           };
 
-          # Verification workflow (runs slower-whisper-verify)
+          # Repository verification workflow
           verify = {
             type = "app";
             program = toString (pkgs.writeShellScript "verify" ''
@@ -331,7 +331,7 @@
               export UV_CACHE_DIR="$PWD/.cache/uv"
               export LD_LIBRARY_PATH="${runtimeLibPath}:''${LD_LIBRARY_PATH:-}"
               export SLOWER_WHISPER_CACHE_ROOT="''${SLOWER_WHISPER_CACHE_ROOT:-$HOME/.cache/slower-whisper}"
-              exec ${pkgs.uv}/bin/uv run slower-whisper-verify "$@"
+              exec ${pkgs.uv}/bin/uv run python scripts/verify_all.py "$@"
             '');
           };
         };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ classifiers = [
 dependencies = [
     "faster-whisper>=1.2.1,<2",
     "typing-extensions>=4.15.0",
+    "jsonschema>=4.26.0",  # Required by the installed validate command and schema contract
 ]
 
 [project.optional-dependencies]
@@ -147,7 +148,6 @@ dev = [
     "httpx>=0.28.1",  # For API BDD tests
     "jiwer>=4.0.0",  # For WER computation in benchmarks
     "pyannote.metrics>=4.0.0",  # For DER computation in benchmarks
-    "jsonschema>=4.26.0",  # For schema validation CLI/tests
     # Code quality (ruff replaces black, isort, flake8)
     "mypy>=1.19.1",
     "ruff>=0.14.14",
@@ -185,9 +185,6 @@ profiling = [
 # Unified CLI
 slower-whisper = "transcription.cli:main"
 
-# Verification and testing CLI (developers)
-slower-whisper-verify = "scripts.verify_all:main"
-
 # Dogfooding workflow CLI (for testing before release)
 slower-whisper-dogfood = "transcription.dogfood:main"
 
@@ -205,11 +202,19 @@ Security = "https://github.com/EffortlessMetrics/slower-whisper/security/policy"
 Support = "https://github.com/EffortlessMetrics/slower-whisper/blob/main/.github/SUPPORT.md"
 Funding = "https://github.com/sponsors/EffortlessMetrics"
 
-[tool.setuptools]
-packages = ["transcription", "transcription.historian", "transcription.historian.analyzers", "transcription.integrations", "scripts", "slower_whisper"]
+[tool.setuptools.packages.find]
+include = ["transcription*", "slower_whisper*"]
+exclude = [
+    "transcription.historian*",
+    "tests*",
+    "benchmarks*",
+    "examples*",
+    "scripts*",
+    "integrations*",
+]
 
 [tool.setuptools.package-data]
-transcription = ["py.typed"]
+transcription = ["py.typed", "schemas/*.json", "schemas/README.md"]
 slower_whisper = ["py.typed"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ Support = "https://github.com/EffortlessMetrics/slower-whisper/blob/main/.github
 Funding = "https://github.com/sponsors/EffortlessMetrics"
 
 [tool.setuptools]
-packages = ["transcription", "transcription.historian", "transcription.historian.analyzers", "transcription.integrations", "scripts", "integrations", "slower_whisper"]
+packages = ["transcription", "transcription.historian", "transcription.historian.analyzers", "transcription.integrations", "scripts", "slower_whisper"]
 
 [tool.setuptools.package-data]
 transcription = ["py.typed"]

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -245,7 +245,7 @@ fi
 
 # Check 5: Quick verification
 run_check "Verification suite" \
-    uv run slower-whisper-verify --quick
+    uv run python scripts/verify_all.py --quick
 
 # Stop here if mode=fast
 if [ "$MODE" = "fast" ]; then

--- a/scripts/verify_bdd_legacy.sh
+++ b/scripts/verify_bdd_legacy.sh
@@ -2,14 +2,14 @@
 # Legacy BDD verification script
 #
 # This script is kept for backward compatibility.
-# It now delegates to the Python CLI for cross-platform support.
+# It now delegates to the repository verifier for cross-platform support.
 #
 # Usage: ./scripts/verify_bdd_legacy.sh
 
 set -e
 
-echo "⚠️  This shell script is deprecated. Use: uv run slower-whisper-verify"
+echo "⚠️  This shell script is deprecated. Use: uv run python scripts/verify_all.py --quick"
 echo ""
 
-# Delegate to Python CLI
+# Delegate to the repository verifier's BDD phase
 exec uv run python -c "from scripts.verify_all import verify_bdd; verify_bdd()"

--- a/tests/test_verify_all.py
+++ b/tests/test_verify_all.py
@@ -7,6 +7,7 @@ These tests verify the verification script itself runs correctly
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -16,12 +17,13 @@ if TYPE_CHECKING:
     pass
 
 ROOT = Path(__file__).parent.parent
+VERIFY_SCRIPT = ROOT / "scripts" / "verify_all.py"
 
 
 def test_verify_help():
-    """Test that --help flag works."""
+    """Test that --help flag works through the repository script."""
     result = subprocess.run(
-        ["uv", "run", "slower-whisper-verify", "--help"],
+        [sys.executable, str(VERIFY_SCRIPT), "--help"],
         cwd=ROOT,
         capture_output=True,
         text=True,

--- a/transcription/audio_utils.py
+++ b/transcription/audio_utils.py
@@ -8,7 +8,14 @@ seeking capabilities. Designed for 16kHz mono WAV files normalized by the pipeli
 from pathlib import Path
 
 import numpy as np
-import soundfile as sf
+
+try:
+    import soundfile as sf
+
+    SOUNDFILE_AVAILABLE = True
+except ImportError:
+    SOUNDFILE_AVAILABLE = False
+    sf = None
 
 
 class AudioSegmentExtractor:
@@ -37,6 +44,12 @@ class AudioSegmentExtractor:
             ValueError: If the file is not a valid audio file.
             RuntimeError: If the audio file cannot be opened.
         """
+        if not SOUNDFILE_AVAILABLE:
+            raise ImportError(
+                "soundfile is required for audio segment extraction. "
+                "Install with: pip install slower-whisper[enrich-basic]"
+            )
+
         self.wav_path = Path(wav_path)
 
         # Validate file exists
@@ -274,6 +287,12 @@ def load_full_audio(wav_path: Path | str) -> tuple[np.ndarray, int]:
         FileNotFoundError: If the file does not exist.
         RuntimeError: If the file cannot be read.
     """
+    if not SOUNDFILE_AVAILABLE:
+        raise ImportError(
+            "soundfile is required for loading audio files. "
+            "Install with: pip install slower-whisper[enrich-basic]"
+        )
+
     wav_path = Path(wav_path)
 
     if not wav_path.exists():
@@ -302,6 +321,9 @@ def validate_wav_file(wav_path: Path | str) -> bool:
     Returns:
         True if valid, False otherwise.
     """
+    if not SOUNDFILE_AVAILABLE:
+        return False
+
     try:
         wav_path = Path(wav_path)
 


### PR DESCRIPTION
## Ruling

This is the canonical **artifact-integrity** change for the v2 recovery campaign in #620.

The prior package configuration could build a wheel that omitted runtime subpackages imported by the advertised CLI, and it did not bundle the normative transcript/stream schemas. The previous wheel smoke tested only the lightweight `slower_whisper` compatibility import, so it could pass while the installed `slower-whisper` command was incomplete.

## What changed

- discover the complete `transcription*` and `slower_whisper*` runtime package trees instead of maintaining an incomplete package list;
- exclude repository-only PR historian, root scripts, examples, tests, benchmarks, deployment files, and root integration tooling from the distribution;
- bundle `transcription/schemas/*.json`, the schema README, and typed-package markers;
- make `jsonschema` a base dependency because `slower-whisper validate` is an installed command;
- remove the checkout-only `slower-whisper-verify` console entry;
- keep repository verification available through `scripts/verify_all.py`, the Nix `verify` app, `make verify*`, and `scripts/ci-local.sh`;
- route scheduled full/API verification and verifier tests through the checkout script rather than the removed packaged entry point;
- retain and exercise the developer-facing `slower-whisper-dogfood` entry point;
- keep optional audio extraction import-safe when `soundfile` is not installed;
- retain the Docker source-copy fixes needed by the current editable-image builds;
- repair the legacy wheel-smoke installer for modern `uv venv` behavior;
- add an `Artifact Integrity` workflow that builds both wheel and sdist, installs each in an isolated environment, changes directory outside the checkout, and exercises installed commands, imports, resources, and wheel contents.

## Installed-artifact contract

The new `artifact-installed` matrix proves:

- `slower-whisper --version`, the advertised command help surfaces, and `slower-whisper-dogfood --help` execute from the installed artifact;
- `slower_whisper`, `transcription`, CLI, benchmark, store, integration, and semantic-provider packages import from `site-packages`;
- transcript and stream schemas are present and parseable;
- missing runtime subpackages cannot be hidden by the checkout;
- repository verifier and PR historian code do not leak into the product wheel;
- the sdist can independently build and install the same product surface.

## Deliberate boundaries

This PR does **not**:

- perform the broad namespace move proposed in #316;
- change ASR fallback semantics;
- claim v2 is released;
- repair streaming, resume, or release promotion;
- repair the separately identified organization-level Gitleaks execution failure.

Useful package-inventory and lazy-public-API work from #316 remains reference material for a later, artifact-gated namespace decision.

## Review map

1. `pyproject.toml` — runtime discovery, package data, validation dependency, and console boundary.
2. `MANIFEST.in` — sdist resource inclusion and repository-only pruning.
3. `.github/workflows/artifact-integrity.yml` — outside-checkout wheel/sdist acceptance.
4. `.github/workflows/ci.yml` — modern `uv` installation for the legacy wheel smoke and explicit Gitleaks secret wiring.
5. `.github/workflows/verify.yml`, `flake.nix`, `Makefile`, and `scripts/ci-local.sh` — repository verification invokes checkout-owned code rather than a published console.
6. `tests/test_verify_all.py` — verifier help is exercised through the repository script.
7. `transcription/audio_utils.py` — optional `soundfile` import guard.
8. `config/Dockerfile*` — narrow source-copy fix for the compatibility package.

## Acceptance

- [x] `artifact-installed (wheel)` passes.
- [x] `artifact-installed (sdist)` passes.
- [x] Legacy wheel smoke passes.
- [x] Python 3.12/3.13, unit, integration, real-model smoke, BDD, benchmark, Nix, Docker, documentation, and repository verification pass on head `99aae634`.
- [x] Wheel contains `transcription/cli_commands`, `transcription/store`, `transcription/benchmark`, and runtime schemas.
- [x] Wheel excludes `transcription/historian` and `scripts/verify_all.py`.

The CI workflow remains red only because the organization-level Gitleaks action exits before scanning when `GITLEAKS_LICENSE` is unavailable. The aggregate `CI Success` job and every repository/product gate owned by this PR pass.

Closes the artifact-integrity portion of #620.