### PR TITLE
🎨 Palette: [UX improvement] Graceful handling of KeyboardInterrupt in CLI prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-01-27 - Graceful Interrupt Handling
+**Learning:** Interactive prompts in CLI apps can cause unhandled stack traces if a user presses Ctrl+C, degrading the user experience.
+**Action:** Wrap CLI `input()` commands in `try...except KeyboardInterrupt` blocks, printing a polite `\nAborted.` message and returning `0` to gracefully handle the interrupt.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,6 +115,18 @@ class TestCacheSubcommand:
         with pytest.raises(SystemExit):
             parser.parse_args(["cache", "--show", "--clear", "all"])
 
+    def test_cache_clear_keyboard_interrupt(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Cache clear handles KeyboardInterrupt gracefully."""
+        with (
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+        ):
+            exit_code = main(["cache", "--clear", "samples"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Aborted." in captured.out
+
     def test_cache_show_displays_info(
         self,
         capsys: pytest.CaptureFixture[str],
@@ -205,6 +217,25 @@ class TestSamplesSubcommand:
         args = parser.parse_args(["samples", "copy", "mini_diarization", "--root", str(tmp_path)])
 
         assert args.root == tmp_path
+
+    def test_samples_copy_keyboard_interrupt(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Samples copy handles KeyboardInterrupt gracefully on overwrite."""
+        # Setup mock to simulate existing files
+        from transcription.exceptions import SampleExistsError
+
+        err = SampleExistsError(message="Files exist", existing_files=[Path("file1.wav")])
+        with (
+            patch("transcription.samples.copy_sample_to_project", side_effect=err),
+            patch("sys.stdin.isatty", return_value=True),
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+        ):
+            exit_code = main(["samples", "copy", "mini_diarization", "--root", str(tmp_path)])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Aborted." in captured.out
 
     def test_samples_generate_parsing(self) -> None:
         """Samples generate action is parsed correctly."""

--- a/tests/test_speaker_identity.py
+++ b/tests/test_speaker_identity.py
@@ -282,6 +282,30 @@ class TestSpeakerRegistry:
         assert result is True
         assert registry.get_speaker(speaker_id) is None
 
+    @patch("sys.stdin.isatty", return_value=True)
+    @patch("builtins.input", side_effect=KeyboardInterrupt)
+    def test_delete_speaker_keyboard_interrupt(self, mock_input, mock_isatty, registry: SpeakerRegistry, sample_embedding: np.ndarray, capsys):
+        """Should handle KeyboardInterrupt gracefully during delete confirmation."""
+        from transcription.speaker_identity import handle_speakers_command
+        import argparse
+
+        speaker_id = registry.register_speaker("Jack", sample_embedding)
+
+        args = argparse.Namespace(
+            speakers_action="delete",
+            speaker_id=speaker_id,
+            force=False,
+            registry=registry.path
+        )
+
+        exit_code = handle_speakers_command(args)
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Aborted." in captured.out
+        # Speaker should still exist
+        assert registry.get_speaker(speaker_id) is not None
+
     def test_delete_nonexistent_speaker(self, registry: SpeakerRegistry):
         """Should return False when deleting nonexistent speaker."""
         result = registry.delete_speaker("nonexistent-id")

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,12 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            except KeyboardInterrupt:
+                print("\nAborted.")
+                return 0
+
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +877,12 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                except KeyboardInterrupt:
+                    print("\nAborted.")
+                    return 0
+
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,7 +1563,12 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 0
+
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
This PR introduces a minor UX improvement to handle `KeyboardInterrupt` gracefully on interactive CLI prompts. By wrapping `input()` with a try-except block, we replace unhandled Python stack traces with a clean `\nAborted.` message and a `0` exit code, ensuring the CLI behaves predictably during forced exits via `Ctrl+C`. Additional unit tests have been added to verify this fallback behavior.

---
*PR created automatically by Jules for task [15382782518164031317](https://jules.google.com/task/15382782518164031317) started by @EffortlessSteven*