### PR TITLE
🎨 Palette: Add visual warning to destructive speaker deletion

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
**💡 What**: Added a red visual warning ("This cannot be undone.") to the interactive CLI confirmation prompt when a user attempts to delete a speaker from the registry.
**🎯 Why**: Deleting a speaker identity is a destructive action that removes the speaker's embedding and metadata from the database. A plain text warning (`Delete speaker 'Name' (ID)? [y/N]`) can be easily skimmed or missed. By highlighting the consequence in red, we add a necessary friction point that increases user attention and reduces the likelihood of accidental deletions.
**📸 Before/After**:
*Before:* `Delete speaker 'Alice' (1234)? [y/N] `
*After:* `Delete speaker 'Alice' (1234)? \033[31mThis cannot be undone.\033[0m [y/N] `
**♿ Accessibility**: The warning text is explicit, meaning the severity of the action is conveyed through both semantics (the words "This cannot be undone.") and visual presentation (color), accommodating users who may not perceive color differences or are in environments without ANSI color support (as `color_utils` automatically degrades to plain text in non-interactive/dumb terminals).

---
*PR created automatically by Jules for task [16393005430455085647](https://jules.google.com/task/16393005430455085647) started by @EffortlessSteven*