### PR TITLE
🎨 Palette: Add destructive action warning to speaker deletion

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,10 +1563,17 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
-        if confirm.lower() not in ("y", "yes"):
-            print("Aborted.")
-            return 0
+        from transcription.color_utils import Colors
+
+        warning = Colors.red("This cannot be undone.")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
+            if confirm.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return 0
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 130
 
     # Delete speaker
     registry.delete_speaker(args.speaker_id)


### PR DESCRIPTION
💡 What: Added a clear, red visual warning and a safe KeyboardInterrupt handler to the speaker deletion confirmation prompt.
🎯 Why: Deleting a speaker identity is a destructive action. As noted in past learnings, plain text warnings are often missed by users. The added red text ensures attention, and the interrupt handler ensures the CLI exits cleanly if the user aborts.
📸 Before/After: Visual change in CLI prompt.
♿ Accessibility: Improves cognitive accessibility and prevents accidental data loss.

---
*PR created automatically by Jules for task [7263820210751920012](https://jules.google.com/task/7263820210751920012) started by @EffortlessSteven*