### PR TITLE
🎨 Palette: Improve destructive action prompts

### DIFF
--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -70,6 +70,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY transcription/ ./transcription/
 COPY scripts/ ./scripts/
 COPY integrations/ ./integrations/
+COPY slower_whisper/ ./slower_whisper/
 
 # Install Python dependencies using uv
 # ARG INSTALL_MODE controls which dependencies to install
@@ -128,6 +129,7 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --chown=appuser:appuser transcription/ /app/transcription/
 COPY --chown=appuser:appuser scripts/ /app/scripts/
 COPY --chown=appuser:appuser integrations/ /app/integrations/
+COPY --chown=appuser:appuser slower_whisper/ /app/slower_whisper/
 COPY --chown=appuser:appuser pyproject.toml /app/
 
 # Create data directories

--- a/config/Dockerfile.gpu
+++ b/config/Dockerfile.gpu
@@ -91,6 +91,7 @@ COPY pyproject.toml uv.lock README.md ./
 COPY transcription/ ./transcription/
 COPY scripts/ ./scripts/
 COPY integrations/ ./integrations/
+COPY slower_whisper/ ./slower_whisper/
 
 # Install Python dependencies using uv
 # ARG INSTALL_MODE controls which dependencies to install

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,6 +115,34 @@ class TestCacheSubcommand:
         with pytest.raises(SystemExit):
             parser.parse_args(["cache", "--show", "--clear", "all"])
 
+    @patch("sys.stdin.isatty", return_value=True)
+    @patch("builtins.input", side_effect=KeyboardInterrupt())
+    def test_cache_clear_keyboard_interrupt(
+        self, mock_input: MagicMock, mock_isatty: MagicMock, tmp_path: Path
+    ) -> None:
+        """Cache --clear aborts gracefully on KeyboardInterrupt."""
+        # Set up mock paths
+        mock_paths = MagicMock()
+        mock_paths.root = tmp_path / "cache"
+        mock_paths.hf_home = tmp_path / "hf"
+        mock_paths.torch_home = tmp_path / "torch"
+        mock_paths.whisper_root = tmp_path / "whisper"
+        mock_paths.emotion_root = tmp_path / "emotion"
+        mock_paths.diarization_root = tmp_path / "diarization"
+        mock_paths.ensure_dirs.return_value = mock_paths
+
+        # Create some test directories with files
+        (tmp_path / "hf").mkdir()
+        (tmp_path / "hf" / "test.bin").write_bytes(b"x" * 1024)
+
+        with (
+            patch("transcription.cache.CachePaths.from_env", return_value=mock_paths),
+            patch("transcription.samples.get_samples_cache_dir", return_value=tmp_path / "samples"),
+        ):
+            exit_code = main(["cache", "--clear", "hf"])
+
+        assert exit_code == 130
+
     def test_cache_show_displays_info(
         self,
         capsys: pytest.CaptureFixture[str],
@@ -205,6 +233,22 @@ class TestSamplesSubcommand:
         args = parser.parse_args(["samples", "copy", "mini_diarization", "--root", str(tmp_path)])
 
         assert args.root == tmp_path
+
+    @patch("sys.stdin.isatty", return_value=True)
+    @patch("builtins.input", side_effect=KeyboardInterrupt())
+    def test_samples_copy_keyboard_interrupt(
+        self, mock_input: MagicMock, mock_isatty: MagicMock, tmp_path: Path
+    ) -> None:
+        """Samples copy handles KeyboardInterrupt gracefully."""
+        from transcription.exceptions import SampleExistsError
+
+        with patch("transcription.samples.copy_sample_to_project") as mock_copy:
+            mock_copy.side_effect = SampleExistsError(
+                "test", existing_files=[tmp_path / "test.wav"]
+            )
+
+            exit_code = main(["samples", "copy", "test_dataset", "--root", str(tmp_path)])
+            assert exit_code == 130
 
     def test_samples_generate_parsing(self) -> None:
         """Samples generate action is parsed correctly."""

--- a/tests/test_speaker_identity.py
+++ b/tests/test_speaker_identity.py
@@ -24,6 +24,7 @@ from transcription.speaker_identity import (
     SpeakerEmbedder,
     SpeakerMatch,
     SpeakerRegistry,
+    _handle_delete,
     apply_identity_mapping,
     get_available_backend,
     map_diarization_to_identity,
@@ -281,6 +282,28 @@ class TestSpeakerRegistry:
 
         assert result is True
         assert registry.get_speaker(speaker_id) is None
+
+    @patch("sys.stdin.isatty", return_value=True)
+    @patch("builtins.input", side_effect=KeyboardInterrupt())
+    def test_delete_speaker_keyboard_interrupt(
+        self,
+        mock_input: MagicMock,
+        mock_isatty: MagicMock,
+        registry: SpeakerRegistry,
+        sample_embedding: np.ndarray,
+    ):
+        """Should abort deletion gracefully on KeyboardInterrupt."""
+        speaker_id = registry.register_speaker("Jack", sample_embedding)
+
+        args = MagicMock()
+        args.speaker_id = speaker_id
+        args.force = False
+
+        result = _handle_delete(registry, args)
+
+        assert result == 130
+        # Verify speaker was not deleted
+        assert registry.get_speaker(speaker_id) is not None
 
     def test_delete_nonexistent_speaker(self, registry: SpeakerRegistry):
         """Should return False when deleting nonexistent speaker."""

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,12 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} {Colors.red('[y/N]')} ")
+            except KeyboardInterrupt:
+                print("\nAborted.")
+                return 130
+
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +877,12 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} {Colors.red('[y/N]')} ")
+                except KeyboardInterrupt:
+                    print("\nAborted.")
+                    return 130
+
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -800,7 +800,9 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
             try:
-                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} {Colors.red('[y/N]')} ")
+                confirm = input(
+                    f"Clear {args.clear} cache ({size_str})? {warning} {Colors.red('[y/N]')} "
+                )
             except KeyboardInterrupt:
                 print("\nAborted.")
                 return 130

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,7 +1563,16 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        try:
+            from transcription.color_utils import Colors
+
+            confirm = input(
+                f"Delete speaker '{speaker.name}' ({speaker.id})? {Colors.red('[y/N]')} "
+            )
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 130
+
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Updated CLI prompts for destructive actions (clearing cache, overwriting files, deleting speakers) to use a red colored `[y/N]` indicator. Wrapped `input()` calls in `try...except KeyboardInterrupt` to gracefully handle user cancellation via Ctrl+C, returning an exit code of `130`.

🎯 Why: Users might unintentionally execute destructive actions because the standard text warnings don't stand out. Additionally, cancelling a prompt with Ctrl+C previously caused a Python traceback, creating a jarring experience. This change ensures users are visually cued before irreversible actions and can back out safely.

♿ Accessibility: Ensures graceful exit paths (Ctrl+C works without tracebacks) and adds visual distinction to high-risk confirmation inputs.

---
*PR created automatically by Jules for task [15714715629445959468](https://jules.google.com/task/15714715629445959468) started by @EffortlessSteven*