### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL Injection in StoreQuery

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-03-25 - SQL Injection in StoreQuery ORDER BY
+**Vulnerability:** SQL Injection via unvalidated dynamic column names in `ORDER BY` clauses in `ConversationStore.search`.
+**Learning:** Dynamic column names in `ORDER BY` clauses cannot be parameterized using standard `?` placeholders in SQLite, leading to direct string concatenation vulnerabilities.
+**Prevention:** Always validate user-provided column names (like `query.order_by`) against a strict hardcoded allowlist of known safe columns before concatenating them into SQL queries.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -27,6 +27,7 @@ from transcription.store import (
     ExportFormat,
     ExportOptions,
     IngestOptions,
+    QueryError,
     QueryFilter,
     SpeakerQuery,
     StoreError,
@@ -485,6 +486,16 @@ class TestFullTextSearch:
 
 class TestQueryFilters:
     """Tests for query filters."""
+
+    def test_invalid_order_by_rejected(
+        self, store: ConversationStore, sample_transcript_json: Path
+    ) -> None:
+        """Test that invalid order_by columns raise a QueryError to prevent SQL injection."""
+        store.ingest(sample_transcript_json)
+
+        query = StoreQuery(order_by="start_time; DROP TABLE segments; --")
+        with pytest.raises(QueryError, match="Invalid order_by column"):
+            store.search(query)
 
     def test_filter_by_speaker(
         self, store: ConversationStore, sample_transcript_json: Path

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,14 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        # Security fix: Validate order_col against allowlist to prevent SQL injection
+        allowed_columns = {"start_time", "end_time", "speaker_id", "speaker_confidence", "rank"}
+        if order_col not in allowed_columns:
+            raise QueryError(
+                f"Invalid order_by column: {order_col}. Must be one of {allowed_columns}"
+            )
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** SQL Injection via unvalidated dynamic column names in `ORDER BY` clauses within `ConversationStore.search`. Because SQLite cannot parameterize column names using standard `?` placeholders, user-provided values in `query.order_by` were directly concatenated into the query string (`sql_parts.append(f"ORDER BY {order_col} {order_dir}")`).
🎯 **Impact:** An attacker could execute arbitrary SQL statements (e.g., `start_time; DROP TABLE segments; --` or `(CASE WHEN 1=1 THEN start_time ELSE end_time END)`) leading to data destruction, unauthorized data access, or denial of service.
🔧 **Fix:** Added a hardcoded allowlist (`{"start_time", "end_time", "speaker_id", "speaker_confidence", "rank"}`) for the `order_col` variable. If the requested column is not in the allowlist, it safely raises a `QueryError`.
✅ **Verification:** Added `test_invalid_order_by_rejected` to `tests/test_conversation_store.py` to ensure invalid SQL values correctly raise `QueryError`. Run tests with `uv run pytest tests/test_conversation_store.py`.

---
*PR created automatically by Jules for task [14512359861407942862](https://jules.google.com/task/14512359861407942862) started by @EffortlessSteven*