### PR TITLE
🎨 Palette: Add destructive action confirmation warning to speaker deletion prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-01-27 - Interruptible Interactive Prompts
+**Learning:** Destructive actions with interactive prompts should be wrappable by `try...except KeyboardInterrupt` blocks to cleanly catch `Ctrl+C` inputs, printing `\nAborted.` and returning an exit code of `130` instead of leaking unhandled stack traces and improving terminal UX.
+**Action:** Wrap all `input()` calls for CLI commands involving destructive actions inside a `try...except KeyboardInterrupt` to accurately signal a process interrupt to the shell and improve terminal UX.

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,10 +1565,15 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
-        if confirm.lower() not in ("y", "yes"):
-            print("Aborted.")
-            return 0
+        try:
+            warning = Colors.red("This cannot be undone.")
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
+            if confirm.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return 0
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 130
 
     # Delete speaker
     registry.delete_speaker(args.speaker_id)


### PR DESCRIPTION
💡 **What:** Added a clear, color-coded warning (`Colors.red("This cannot be undone.")`) to the `delete speaker` CLI prompt and wrapped the `input()` call in a `try...except KeyboardInterrupt` block.
🎯 **Why:** To make the destructive action of deleting a speaker visually distinct, ensuring users are fully aware of the consequences. Additionally, catching `KeyboardInterrupt` improves the terminal UX by cleanly handling `Ctrl+C` with an "Aborted" message and standard `130` exit code, rather than polluting the terminal with a Python traceback.
📸 **Before/After:** Before, the prompt was a simple text confirmation, and a `Ctrl+C` would leak an unhandled exception. After, a distinct red warning enforces attention, and `Ctrl+C` exits cleanly.
♿ **Accessibility:** Color contrast and visual distinction for critical warnings help users navigate safely and prevent accidental data loss. Standardized `SIGINT` handling provides a more predictable CLI experience.

---
*PR created automatically by Jules for task [4406228504094744575](https://jules.google.com/task/4406228504094744575) started by @EffortlessSteven*