### PR TITLE
🎨 Palette: Add destructive action warning to speaker delete prompt

### DIFF
--- a/tests/test_speaker_identity.py
+++ b/tests/test_speaker_identity.py
@@ -160,6 +160,35 @@ class TestSpeakerRegistry:
         finally:
             registry.close()
 
+
+class TestSpeakerCLI:
+    """Tests for speaker CLI command handlers."""
+
+    def test_handle_delete_interactive_prompt_abort(self):
+        """Tests that answering no or Ctrl+C aborts the deletion safely."""
+        from transcription.speaker_identity import _handle_delete
+
+        registry = MagicMock()
+        speaker = MagicMock()
+        speaker.name = "TestUser"
+        speaker.id = "123"
+        registry.get_speaker.return_value = speaker
+
+        args = MagicMock()
+        args.speaker_id = "123"
+        args.force = False
+
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch("builtins.input", return_value="n"):
+                exit_code = _handle_delete(registry, args)
+                assert exit_code == 0
+                assert not registry.delete_speaker.called
+
+            with patch("builtins.input", side_effect=KeyboardInterrupt()):
+                exit_code = _handle_delete(registry, args)
+                assert exit_code == 130
+                assert not registry.delete_speaker.called
+
     def test_registry_creates_schema(self, temp_db: Path):
         """Registry should create required tables."""
         registry = SpeakerRegistry(temp_db)

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,10 +1565,15 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
-        if confirm.lower() not in ("y", "yes"):
-            print("Aborted.")
-            return 0
+        try:
+            warning = Colors.red("This cannot be undone.")
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
+            if confirm.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return 0
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 130
 
     # Delete speaker
     registry.delete_speaker(args.speaker_id)


### PR DESCRIPTION
💡 **What:** Added a clear visual warning in red ("This cannot be undone.") to the `_handle_delete` interactive prompt in `speaker_identity.py`. Additionally, gracefully catches `KeyboardInterrupt` (Ctrl+C) to abort the action without a stack trace.
🎯 **Why:** Deleting a speaker identity is a destructive action. The previous plain-text prompt lacked emphasis, making it easy to accidentally agree. Additionally, hitting `Ctrl+C` caused an ugly stack trace.
📸 **Before/After:**
*Before:* `Delete speaker 'Alice' (uuid-123)? [y/N]`
*After:* `Delete speaker 'Alice' (uuid-123)? \033[31mThis cannot be undone.\033[0m [y/N]` (Plus safe abortion on `Ctrl+C`).
♿ **Accessibility:** Enhanced visual feedback for destructive actions to prevent user errors, and improved keyboard usability by supporting graceful abortion via standard interrupt bindings.

---
*PR created automatically by Jules for task [15371507942424234533](https://jules.google.com/task/15371507942424234533) started by @EffortlessSteven*