### PR TITLE
🎨 Palette: Add KeyboardInterrupt handling to interactive CLI prompts

### DIFF
--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -43,6 +43,21 @@ class TestCacheClearConfirmation:
             captured = capsys.readouterr()
             assert "Cleared Whisper cache" in captured.out
 
+    def test_interactive_prompt_keyboard_interrupt_aborts(self, mock_cache_paths, capsys):
+        """KeyboardInterrupt in prompt aborts clearing."""
+        with (
+            patch("shutil.rmtree") as mock_rmtree,
+            patch("builtins.input", side_effect=KeyboardInterrupt()) as mock_input,
+            patch("sys.stdin.isatty", return_value=True),
+        ):
+            exit_code = main(["cache", "--clear", "whisper"])
+
+            assert exit_code == 130
+            assert mock_input.called
+            assert not mock_rmtree.called
+            captured = capsys.readouterr()
+            assert "Aborted" in captured.out
+
     def test_interactive_prompt_no_aborts(self, mock_cache_paths, capsys):
         """Answering 'n' to prompt aborts without clearing."""
         with (

--- a/tests/test_samples_ux.py
+++ b/tests/test_samples_ux.py
@@ -42,6 +42,22 @@ class TestSamplesCopyUX:
 
         assert exit_code == 1
 
+    def test_copy_conflict_interactive_keyboard_interrupt(self, mock_copy, tmp_path, capsys):
+        """KeyboardInterrupt in copy with conflicts should prompt and abort."""
+        mock_copy.side_effect = SampleExistsError("Conflict", [Path("file1.wav")])
+
+        # Patch isatty to True and input to KeyboardInterrupt
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch("builtins.input", side_effect=KeyboardInterrupt()):
+                exit_code = main(["samples", "copy", "mini_diarization", "--root", str(tmp_path)])
+
+        assert exit_code == 130
+        captured = capsys.readouterr()
+        assert "Aborted." in captured.out
+        assert mock_copy.call_count == 1
+
+        mock_copy.reset_mock()
+
     def test_copy_conflict_interactive_abort(self, mock_copy, tmp_path, capsys):
         """Interactive copy with conflicts should prompt and abort if user says no."""
         mock_copy.side_effect = SampleExistsError("Conflict", [Path("file1.wav")])

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,11 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            except KeyboardInterrupt:
+                print("\nAborted.")
+                return 130
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +876,11 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                except KeyboardInterrupt:
+                    print("\nAborted.")
+                    return 130
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,12 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 130
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
**What:** Added graceful handling of KeyboardInterrupt (Ctrl+C) in interactive CLI confirmation prompts.
**Why:** Improves user experience by avoiding unhandled traceback dumps when the user aborts an action using Ctrl+C.
**Accessibility:** Also added clear red warnings for speaker deletion action to make destructive nature clear before pressing Y.

---
*PR created automatically by Jules for task [14804900410693754062](https://jules.google.com/task/14804900410693754062) started by @EffortlessSteven*