### PR TITLE
🎨 Palette: Add visual warning to speaker delete confirmation

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,10 +1565,15 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
-        if confirm.lower() not in ("y", "yes"):
-            print("Aborted.")
-            return 0
+        try:
+            warning = Colors.red("This cannot be undone.")
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
+            if confirm.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return 0
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 130
 
     # Delete speaker
     registry.delete_speaker(args.speaker_id)


### PR DESCRIPTION
What: Added a red warning and Ctrl+C handling to the destructive speaker delete CLI prompt.
Why: Destructive actions need distinct visual warnings, and Ctrl+C should be handled gracefully.
Accessibility: Improves cognitive accessibility by clearly highlighting irreversible actions.

---
*PR created automatically by Jules for task [12835189875293383327](https://jules.google.com/task/12835189875293383327) started by @EffortlessSteven*