### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery order_by

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-03-31 - [SQL Injection in StoreQuery]
+**Vulnerability:** Dynamic column names in ORDER BY clauses without allowlisting.
+**Learning:** SQLite standard placeholders (?) cannot parameterize column names in ORDER BY. This leads to SQL injection.
+**Prevention:** Always validate user-provided column names against a strict allowlist of known safe columns before concatenating them into SQL strings.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -27,6 +27,7 @@ from transcription.store import (
     ExportFormat,
     ExportOptions,
     IngestOptions,
+    QueryError,
     QueryFilter,
     SpeakerQuery,
     StoreError,
@@ -904,6 +905,11 @@ class TestErrorHandling:
         query = StoreQuery()
         results = store.search(query)
         assert len(results) == 4
+
+        # Invalid order_by column should raise QueryError
+        query = StoreQuery(order_by="invalid_column; DROP TABLE users;")
+        with pytest.raises(QueryError, match="Invalid order_by column"):
+            store.search(query)
 
 
 # =============================================================================

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -922,8 +922,14 @@ class SQLiteConversationStore:
         order_col = "rank" if query.text else query.order_by
 
         valid_order_cols = {
-            "start_time", "end_time", "segment_index", "speaker_confidence",
-            "rank", "segment_id", "transcript_id", "file_name"
+            "start_time",
+            "end_time",
+            "segment_index",
+            "speaker_confidence",
+            "rank",
+            "segment_id",
+            "transcript_id",
+            "file_name",
         }
         if order_col not in valid_order_cols:
             raise QueryError(f"Invalid order_by column: {order_col}")

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,14 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        valid_order_cols = {
+            "start_time", "end_time", "segment_index", "speaker_confidence",
+            "rank", "segment_id", "transcript_id", "file_name"
+        }
+        if order_col not in valid_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Dynamic column names in ORDER BY clauses without allowlisting lead to SQL injection.
🎯 Impact: An attacker can inject arbitrary SQL commands.
🔧 Fix: Added an allowlist of valid columns for the ORDER BY clause.
✅ Verification: Added unit tests and ran the test suite.

---
*PR created automatically by Jules for task [10405906025335102091](https://jules.google.com/task/10405906025335102091) started by @EffortlessSteven*