### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery.order_by

### DIFF
--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -27,6 +27,7 @@ from transcription.store import (
     ExportFormat,
     ExportOptions,
     IngestOptions,
+    QueryError,
     QueryFilter,
     SpeakerQuery,
     StoreError,
@@ -463,6 +464,22 @@ class TestFullTextSearch:
         results = store.search(query)
 
         assert len(results) == 0
+
+    def test_search_order_by_sql_injection(
+        self, store: ConversationStore, sample_transcript_json: Path
+    ) -> None:
+        """Test that invalid order_by values are rejected to prevent SQL injection."""
+        store.ingest(sample_transcript_json)
+
+        # Valid order_by should work
+        query_valid = StoreQuery(order_by="start_time")
+        results_valid = store.search(query_valid)
+        assert len(results_valid) == 4
+
+        # Invalid order_by should raise QueryError
+        query_invalid = StoreQuery(order_by="start_time; DROP TABLE segments; --")
+        with pytest.raises(QueryError, match="Invalid order_by column"):
+            store.search(query_invalid)
 
     def test_search_with_snippet_highlighting(
         self, store: ConversationStore, sample_transcript_json: Path

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -918,6 +918,21 @@ class SQLiteConversationStore:
                 sql_parts.append("AND t.ingested_at < ?")
                 params.append(query.date_range.before)
 
+        # Validate order_by to prevent SQL injection
+        allowed_order_by = {
+            "start_time",
+            "end_time",
+            "segment_index",
+            "speaker_id",
+            "speaker_confidence",
+            "rank",
+            "file_name",
+            "language",
+        }
+
+        if query.order_by not in allowed_order_by:
+            raise QueryError(f"Invalid order_by column: {query.order_by}")
+
         # Order by
         order_col = "rank" if query.text else query.order_by
         order_dir = "DESC" if query.order_desc else "ASC"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `StoreQuery`'s `order_by` parameter was concatenated directly into an `ORDER BY` clause string (`f"ORDER BY {order_col} {order_dir}"`) without validation or parameterization. This allowed attackers to inject arbitrary SQL statements using the `order_by` field.
🎯 **Impact:** SQL Injection. An attacker could extract data, modify database state, or execute denial of service attacks by passing malicious input like `"start_time; DROP TABLE segments; --"`.
🔧 **Fix:** Introduced an explicit allowlist `allowed_order_by` for valid sort columns. The application now raises a `QueryError` if the `order_by` field is not in the allowlist.
✅ **Verification:** Verified by checking valid requests complete successfully and verifying invalid requests successfully raise `QueryError`, which were both added as explicit test cases in `test_conversation_store.py`.

---
*PR created automatically by Jules for task [396745750267023994](https://jules.google.com/task/396745750267023994) started by @EffortlessSteven*