### PR TITLE
🎨 Palette: Add confirmation warning to samples copy

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -872,7 +872,8 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                warning = Colors.red("This cannot be undone.")
+                confirm = input(f"Overwrite? {warning} [y/N] ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
💡 What: Added the standard destructive warning 'This cannot be undone.' to the samples copy prompt.
🎯 Why: Users need explicit visual warning when overwriting files.
📸 Before/After: N/A
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [124643588073068280](https://jules.google.com/task/124643588073068280) started by @EffortlessSteven*