### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in ConversationStore

### DIFF
--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -27,6 +27,7 @@ from transcription.store import (
     ExportFormat,
     ExportOptions,
     IngestOptions,
+    QueryError,
     QueryFilter,
     SpeakerQuery,
     StoreError,
@@ -476,6 +477,11 @@ class TestFullTextSearch:
         assert len(results) >= 1
         # FTS5 should include <mark> tags for highlighting
         assert "snippet" in results[0]
+
+    def test_search_sql_injection_order_by(self, store: ConversationStore) -> None:
+        """Test that invalid order_by columns raise QueryError."""
+        with pytest.raises(QueryError, match="Invalid order_by column"):
+            store.search(StoreQuery(order_by="start_time; DROP TABLE segments; --"))
 
 
 # =============================================================================

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,25 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        # Validate order_col to prevent SQL injection
+        valid_columns = {
+            "rank",
+            "id",
+            "segment_id",
+            "transcript_id",
+            "segment_index",
+            "start_time",
+            "end_time",
+            "text",
+            "speaker_id",
+            "speaker_confidence",
+            "file_name",
+            "language",
+        }
+        if order_col not in valid_columns:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `ConversationStore.search()` method was taking the `order_by` property from user-provided query input and directly interpolating it into the `ORDER BY` SQL clause without validation.
🎯 **Impact:** An attacker could craft a malicious request containing SQL syntax in the `order_by` field, leading to blind SQL injection, potentially exfiltrating sensitive transcript data or causing denial of service.
🔧 **Fix:** Implemented an explicit allowlist of valid column names that the `order_by` property must match. If it does not match, a `QueryError` is immediately raised. This is the correct defense because standard parameterization `?` does not work for SQL identifiers like column names.
✅ **Verification:** A test suite run confirms the fix blocks standard SQL injection strings while still allowing valid queries to sort successfully. No existing tests were broken.

---
*PR created automatically by Jules for task [3187570035028167175](https://jules.google.com/task/3187570035028167175) started by @EffortlessSteven*