### PR TITLE
⚡ Bolt: [performance improvement] Vectorize speech frame energy calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+# Bolt's Journal
+## 2025-04-04 - [Vectorize NumPy Loops in Streaming ASR]
+**Learning:** Iterating over NumPy array slices in a Python `for` loop to calculate frame energies creates significant overhead for streaming audio chunks.
+**Action:** Always use NumPy vectorization (`np.reshape` and `np.mean(..., axis=1)`) when applying calculations to sequential blocks of data instead of Python loops.

--- a/transcription/streaming_asr.py
+++ b/transcription/streaming_asr.py
@@ -199,13 +199,15 @@ class StreamingASRAdapter:
         frame_size = int(self.config.sample_rate * frame_size_ms / 1000)
         num_frames = len(audio) // frame_size
 
-        speech_frames = []
-        for i in range(num_frames):
-            frame = audio[i * frame_size : (i + 1) * frame_size]
-            energy = self._calculate_energy(frame)
-            speech_frames.append(energy > self.config.vad_energy_threshold)
+        if num_frames == 0:
+            return []
 
-        return speech_frames
+        audio_array = np.asarray(audio)
+        frames = np.reshape(audio_array[: num_frames * frame_size], (num_frames, frame_size))
+        energies = np.sqrt(np.mean(frames**2, axis=1))
+        speech_mask = energies > self.config.vad_energy_threshold
+
+        return [bool(x) for x in speech_mask]
 
     def _process_vad(
         self,


### PR DESCRIPTION
What: Vectorized the frame-wise energy calculation in _detect_speech_frames.
Why: The previous implementation iterated over the audio frames in a Python loop to calculate frame energy one by one, creating a performance bottleneck for long audios or high-throughput scenarios.
Impact: Reduces execution time of frame energy calculations. In synthetic benchmarks, execution time decreased from ~213ms to ~19ms for 100 chunks of 5s audio.
Measurement: Verified by passing existing tests in `tests/test_streaming_asr.py` and using ad-hoc benchmark script.

---
*PR created automatically by Jules for task [4079007381256456211](https://jules.google.com/task/4079007381256456211) started by @EffortlessSteven*