### PR TITLE
🎨 Palette: [UX improvement] Add warning to speaker delete confirmation

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 **What:** Added a distinct red warning to the speaker delete confirmation prompt.
🎯 **Why:** To enforce attention for this destructive action, preventing accidental deletions as outlined in `.jules/palette.md`.
📸 **Before/After:** The prompt now explicitly reads `This cannot be undone.` in red.
♿ **Accessibility:** Enhances clarity and safety for destructive actions.

---
*PR created automatically by Jules for task [18257159038397812375](https://jules.google.com/task/18257159038397812375) started by @EffortlessSteven*