### PR TITLE
🎨 Palette: Add destructive action warning for speaker deletion

### DIFF
--- a/tests/test_speaker_identity.py
+++ b/tests/test_speaker_identity.py
@@ -24,6 +24,7 @@ from transcription.speaker_identity import (
     SpeakerEmbedder,
     SpeakerMatch,
     SpeakerRegistry,
+    _handle_delete,
     apply_identity_mapping,
     get_available_backend,
     map_diarization_to_identity,
@@ -675,3 +676,78 @@ class TestSpeakerIdentityIntegration:
 
         finally:
             registry.close()
+
+
+class TestCliHandlers:
+    """Test CLI handler functions."""
+
+    def test_handle_delete_force(self, registry: SpeakerRegistry, sample_embedding: np.ndarray):
+        """Test deleting a speaker with --force."""
+
+        class Args:
+            speaker_id = registry.register_speaker("TestSpeaker", sample_embedding)
+            force = True
+
+        result = _handle_delete(registry, Args())
+        assert result == 0
+        assert registry.get_speaker(Args.speaker_id) is None
+
+    def test_handle_delete_interactive_confirm(
+        self, registry: SpeakerRegistry, sample_embedding: np.ndarray
+    ):
+        """Test deleting a speaker interactively with confirmation."""
+        from unittest.mock import patch
+
+        class Args:
+            speaker_id = registry.register_speaker("TestSpeaker", sample_embedding)
+            force = False
+
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch("builtins.input", return_value="y"):
+                result = _handle_delete(registry, Args())
+
+        assert result == 0
+        assert registry.get_speaker(Args.speaker_id) is None
+
+    def test_handle_delete_interactive_abort(
+        self, registry: SpeakerRegistry, sample_embedding: np.ndarray
+    ):
+        """Test deleting a speaker interactively with abort."""
+        from unittest.mock import patch
+
+        class Args:
+            speaker_id = registry.register_speaker("TestSpeaker", sample_embedding)
+            force = False
+
+        with patch("sys.stdin.isatty", return_value=True):
+            with patch("builtins.input", return_value="n"):
+                result = _handle_delete(registry, Args())
+
+        assert result == 0
+        assert registry.get_speaker(Args.speaker_id) is not None
+
+    def test_handle_delete_non_interactive_no_force(
+        self, registry: SpeakerRegistry, sample_embedding: np.ndarray
+    ):
+        """Test deleting a speaker non-interactively without --force."""
+        from unittest.mock import patch
+
+        class Args:
+            speaker_id = registry.register_speaker("TestSpeaker", sample_embedding)
+            force = False
+
+        with patch("sys.stdin.isatty", return_value=False):
+            result = _handle_delete(registry, Args())
+
+        assert result == 1
+        assert registry.get_speaker(Args.speaker_id) is not None
+
+    def test_handle_delete_not_found(self, registry: SpeakerRegistry):
+        """Test deleting a speaker that does not exist."""
+
+        class Args:
+            speaker_id = "nonexistent"
+            force = True
+
+        result = _handle_delete(registry, Args())
+        assert result == 1

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
**What:** Added a prominent visual warning when deleting a speaker.
**Why:** Destructive actions require distinct visual warnings to enforce user attention and prevent accidental deletions.
**Accessibility:** Uses terminal colors to clearly indicate destructive intent.

---
*PR created automatically by Jules for task [10753848095461175989](https://jules.google.com/task/10753848095461175989) started by @EffortlessSteven*