### PR TITLE
🎨 Palette: Add destructive warning to sample copy prompt

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -872,7 +872,8 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                warning = Colors.red("This cannot be undone.")
+                confirm = input(f"Overwrite? {warning} [y/N] ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
Added explicit 'This cannot be undone.' warning to the samples copy overwrite prompt to improve UX and prevent accidental data loss, following the guidelines in .jules/palette.md.

---
*PR created automatically by Jules for task [6425326378831207187](https://jules.google.com/task/6425326378831207187) started by @EffortlessSteven*