### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in store search query

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2026-01-29 - SQLite SQL Injection in ORDER BY
+**Vulnerability:** SQL injection vulnerability in `ConversationStore.search()` where the `order_by` field was directly interpolated into the query via an f-string (`f"ORDER BY {order_col} {order_dir}"`).
+**Learning:** Standard SQLite parameterization (`?`) does not support dynamic column names in `ORDER BY` clauses, making string interpolation a common but dangerous pattern if user input is not validated.
+**Prevention:** Always use a strict allowlist (whitelist) of permitted column names to validate user-provided sorting or grouping keys before using them in SQL string interpolation.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -401,6 +401,16 @@ class TestIngestion:
 class TestFullTextSearch:
     """Tests for FTS5 full-text search."""
 
+    def test_search_sql_injection_prevention(self, store: ConversationStore) -> None:
+        """Test that SQL injection via order_by is prevented."""
+        import pytest
+
+        from transcription.store.types import QueryError
+
+        query = StoreQuery(order_by="start_time; DROP TABLE users;")
+        with pytest.raises(QueryError, match="Invalid order_by column"):
+            store.search(query)
+
     def test_search_text_phrase(
         self, store: ConversationStore, sample_transcript_json: Path
     ) -> None:

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -919,7 +919,20 @@ class SQLiteConversationStore:
                 params.append(query.date_range.before)
 
         # Order by
+        # Prevent SQL injection by strictly validating the order column
+        allowed_order_cols = {
+            "rank",
+            "start_time",
+            "end_time",
+            "speaker_id",
+            "speaker_confidence",
+            "language",
+            "file_name",
+        }
         order_col = "rank" if query.text else query.order_by
+        if order_col not in allowed_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `ConversationStore.search()` method in `transcription/store/store.py` used string formatting with user input for the `ORDER BY` clause (`f"ORDER BY {order_col} {order_dir}"`). This allowed for SQL injection attacks, as `query.order_by` was not validated and standard SQLite parameterization (`?`) does not support dynamic column names in `ORDER BY` clauses.
🎯 **Impact:** An attacker could execute arbitrary SQL commands (e.g., `start_time; DROP TABLE users;`) and compromise the database.
🔧 **Fix:** Implemented an allowlist (`allowed_order_cols`) to strictly validate the user-provided `order_by` column name against a predefined set of safe column names. If an invalid column name is provided, a `QueryError` is raised.
✅ **Verification:** Added a new unit test `test_search_sql_injection_prevention` in `tests/test_conversation_store.py` to ensure that invalid `order_by` values correctly raise a `QueryError` and prevent SQL injection. Ran `uv run pytest tests/test_conversation_store.py` to verify the fix and ensure no regressions.

---
*PR created automatically by Jules for task [7898819499407365222](https://jules.google.com/task/7898819499407365222) started by @EffortlessSteven*