### PR TITLE
🎨 Palette: Add viewport meta tag to HTML export for mobile readability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-01-27 - Viewport Meta Tag for Exported Artifacts
+**Learning:** Exported standalone HTML files (like transcripts) often omit the viewport meta tag, causing mobile browsers to render them at desktop width and scale them down, resulting in unreadable text.
+**Action:** Always verify that standalone HTML templates include `<meta name="viewport" content="width=device-width, initial-scale=1.0" />` to ensure proper mobile readability and scaling.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,7 +33,6 @@ include requirements-dev.txt
 # Typed package markers
 include transcription/py.typed
 include slower_whisper/py.typed
-recursive-include slower_whisper *.py
 
 # Docs and examples
 recursive-include docs *.md *.txt *.json *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -33,6 +33,7 @@ include requirements-dev.txt
 # Typed package markers
 include transcription/py.typed
 include slower_whisper/py.typed
+recursive-include slower_whisper *.py
 
 # Docs and examples
 recursive-include docs *.md *.txt *.json *.py

--- a/transcription/exporters.py
+++ b/transcription/exporters.py
@@ -116,6 +116,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
         "<html>",
         "<head>",
         '<meta charset="utf-8" />',
+        '<meta name="viewport" content="width=device-width, initial-scale=1.0" />',
         "<title>Transcript</title>",
         "<style>",
         "body { font-family: system-ui, sans-serif; color: #222; margin: 24px; }",


### PR DESCRIPTION
💡 What: Added the <meta name="viewport"> tag to the HTML export template.
🎯 Why: Without this tag, exported HTML transcripts will render at desktop width and be scaled down on mobile devices, making the text unreadable without zooming.
📸 Before/After: Not applicable (invisible change).
♿ Accessibility: Improves mobile readability and accessibility.

---
*PR created automatically by Jules for task [9907823069764286929](https://jules.google.com/task/9907823069764286929) started by @EffortlessSteven*