### PR TITLE
🎨 Palette: Add red warning color to cache clear prompt size

### DIFF
--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -43,6 +43,10 @@ class TestCacheClearConfirmation:
             captured = capsys.readouterr()
             assert "Cleared Whisper cache" in captured.out
 
+            prompt_arg = mock_input.call_args[0][0]
+            from transcription.color_utils import Colors
+            assert Colors.red("0 B") in prompt_arg
+
     def test_interactive_prompt_no_aborts(self, mock_cache_paths, capsys):
         """Answering 'n' to prompt aborts without clearing."""
         with (

--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -45,6 +45,7 @@ class TestCacheClearConfirmation:
 
             prompt_arg = mock_input.call_args[0][0]
             from transcription.color_utils import Colors
+
             assert Colors.red("0 B") in prompt_arg
 
     def test_interactive_prompt_no_aborts(self, mock_cache_paths, capsys):

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -797,7 +797,7 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
 
             # Only calculate size when prompting (skip expensive traversal when --force)
             total_size = sum(_get_cache_size(path) for _, path in targets)
-            size_str = _format_size(total_size)
+            size_str = Colors.red(_format_size(total_size))
             warning = Colors.red("This cannot be undone.")
             confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
             if confirm.lower() not in ("y", "yes"):


### PR DESCRIPTION
💡 What: Made cache clear size red. 🎯 Why: Better visual warning for destructive action. 📸 Before/After: Size is now red. ♿ Accessibility: Color adds emphasis.

---
*PR created automatically by Jules for task [6225855677824600599](https://jules.google.com/task/6225855677824600599) started by @EffortlessSteven*