### PR TITLE
⚡ Bolt: [performance improvement] Vectorize VAD energy calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-10-27 - Vectorizing frame-wise audio processing loops
+**Learning:** Using Python `for` loops to iterate over and slice numpy arrays drops out of C-level vectorization, creating a massive bottleneck in hot paths like VAD energy calculations.
+**Action:** Use `np.reshape` to convert the 1D audio array into a 2D `(num_frames, frame_size)` array, then use `axis=1` operations (e.g., `np.mean(frames**2, axis=1)`) to maintain C-level performance. Ensure boolean numpy arrays are cast properly using list comprehensions (`[bool(x) for x in array]`) to satisfy strict typing.

--- a/tests/test_streaming_asr.py
+++ b/tests/test_streaming_asr.py
@@ -139,39 +139,6 @@ class TestStreamingASRAdapter:
         # Should be close to 1.0 (32767/32768)
         assert float32[0] == pytest.approx(32767 / 32768, rel=1e-4)
 
-    def test_calculate_energy_silence(self):
-        """Test energy calculation for silence."""
-        model = MockWhisperModel()
-        adapter = StreamingASRAdapter(model)
-
-        silence = np.zeros(1600, dtype=np.float32)
-        energy = adapter._calculate_energy(silence)
-
-        assert energy == 0.0
-
-    def test_calculate_energy_signal(self):
-        """Test energy calculation for non-zero signal."""
-        model = MockWhisperModel()
-        adapter = StreamingASRAdapter(model)
-
-        # Sine wave should have non-zero energy
-        t = np.linspace(0, 1, 16000, dtype=np.float32)
-        signal = 0.5 * np.sin(2 * np.pi * 440 * t)  # 440 Hz tone
-        energy = adapter._calculate_energy(signal)
-
-        assert energy > 0.0
-        assert energy < 1.0
-
-    def test_calculate_energy_empty(self):
-        """Test energy calculation for empty array."""
-        model = MockWhisperModel()
-        adapter = StreamingASRAdapter(model)
-
-        empty = np.array([], dtype=np.float32)
-        energy = adapter._calculate_energy(empty)
-
-        assert energy == 0.0
-
     @pytest.mark.asyncio
     async def test_ingest_audio_empty(self):
         """Test ingesting empty audio."""

--- a/transcription/streaming_asr.py
+++ b/transcription/streaming_asr.py
@@ -173,19 +173,6 @@ class StreamingASRAdapter:
 
         return float32_array
 
-    def _calculate_energy(self, audio: np.ndarray) -> float:
-        """Calculate RMS energy of audio segment.
-
-        Args:
-            audio: Float32 audio array.
-
-        Returns:
-            RMS energy value (0.0-1.0 for normalized audio).
-        """
-        if len(audio) == 0:
-            return 0.0
-        return float(np.sqrt(np.mean(audio**2)))
-
     def _detect_speech_frames(self, audio: np.ndarray, frame_size_ms: int = 30) -> list[bool]:
         """Detect speech in audio using frame-wise energy analysis.
 
@@ -199,13 +186,29 @@ class StreamingASRAdapter:
         frame_size = int(self.config.sample_rate * frame_size_ms / 1000)
         num_frames = len(audio) // frame_size
 
-        speech_frames = []
-        for i in range(num_frames):
-            frame = audio[i * frame_size : (i + 1) * frame_size]
-            energy = self._calculate_energy(frame)
-            speech_frames.append(energy > self.config.vad_energy_threshold)
+        if num_frames == 0:
+            return []
 
-        return speech_frames
+        # Ensure we have a numpy array
+        audio_np = np.asarray(audio, dtype=np.float32)
+
+        # Truncate audio to exact multiple of frame_size
+        truncated_audio = audio_np[: num_frames * frame_size]
+
+        # Reshape to (num_frames, frame_size)
+        frames = np.reshape(truncated_audio, (num_frames, frame_size))
+
+        # Vectorized RMS energy calculation over axis 1 (the frames)
+        # mean(audio^2)
+        mean_squares = np.mean(frames**2, axis=1)
+        # sqrt(mean(audio^2))
+        energies = np.sqrt(mean_squares)
+
+        # Vectorized comparison against threshold
+        is_speech = energies > self.config.vad_energy_threshold
+
+        # Explicitly cast to list of booleans to satisfy strict typing
+        return [bool(x) for x in is_speech]
 
     def _process_vad(
         self,


### PR DESCRIPTION
💡 **What**: Refactored `_detect_speech_frames` in `transcription/streaming_asr.py` to use vectorized numpy operations and removed the explicit python `for` loop and the unused `_calculate_energy` helper method. Cleaned up associated tests in `tests/test_streaming_asr.py`.
🎯 **Why**: Running python `for` loops to slice and calculate the RMS energy of numpy arrays frame-by-frame creates a massive bottleneck because it drops out of C-level vectorization. This occurs in a hot path (streaming voice activity detection), meaning every millisecond counts.
📊 **Impact**: VAD energy calculations now execute at C-level speeds, drastically reducing CPU overhead and latency during streaming transcription.
🔬 **Measurement**: Verified the algorithmic equivalence by ensuring the entire test suite (`uv run pytest tests/test_streaming_asr.py`) passes without modifications to the actual VAD logic tests.

---
*PR created automatically by Jules for task [15592330574394073925](https://jules.google.com/task/15592330574394073925) started by @EffortlessSteven*