### PR TITLE
🎨 Palette: Add critical red warning to speaker delete action

### DIFF
--- a/tests/test_speaker_identity.py
+++ b/tests/test_speaker_identity.py
@@ -675,3 +675,49 @@ class TestSpeakerIdentityIntegration:
 
         finally:
             registry.close()
+
+
+def test_handle_delete_command_interactive(
+    registry: SpeakerRegistry, sample_embedding: np.ndarray, monkeypatch
+):
+    """Should delete speaker interactively when user inputs 'y'."""
+    import argparse
+
+    from transcription.speaker_identity import _handle_delete
+
+    speaker_id = registry.register_speaker("Test Speaker", sample_embedding)
+    args = argparse.Namespace(speaker_id=speaker_id, force=False)
+
+    # Mock sys.stdin.isatty to simulate interactive terminal
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    # Mock input to return 'y'
+    monkeypatch.setattr("builtins.input", lambda prompt: "y")
+
+    result = _handle_delete(registry, args)
+
+    assert result == 0
+    assert registry.get_speaker(speaker_id) is None
+
+
+def test_handle_delete_command_interactive_abort(
+    registry: SpeakerRegistry, sample_embedding: np.ndarray, monkeypatch
+):
+    """Should not delete speaker interactively when user inputs 'n'."""
+    import argparse
+
+    from transcription.speaker_identity import _handle_delete
+
+    speaker_id = registry.register_speaker("Test Speaker", sample_embedding)
+    args = argparse.Namespace(speaker_id=speaker_id, force=False)
+
+    # Mock sys.stdin.isatty to simulate interactive terminal
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    # Mock input to return 'n'
+    monkeypatch.setattr("builtins.input", lambda prompt: "n")
+
+    result = _handle_delete(registry, args)
+
+    assert result == 0
+    assert registry.get_speaker(speaker_id) is not None

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,7 +1563,10 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        from transcription.color_utils import Colors
+
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Made the delete action warning red in the prompt.
🎯 Why: Brings consistency to destructive action warnings to make sure they are clearly seen by users.
📸 Before/After: Not visual in browser, visual in terminal prompt.
♿ Accessibility: Improves visual salience of non-recoverable actions.

---
*PR created automatically by Jules for task [12737496808467700653](https://jules.google.com/task/12737496808467700653) started by @EffortlessSteven*