### PR TITLE
🎨 Palette: Add red color to speaker delete prompt

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red(f"Delete speaker '{speaker.name}' ({speaker.id})?")
+        confirm = input(f"{warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added red color formatting to the destructive delete speaker prompt.
🎯 Why: Based on a previous UX learning, plain text warnings for destructive actions are often missed. Applying a distinct red warning (`Colors.red()`) enforces attention and makes the CLI safer and more intuitive to use.
📸 Before/After: Visual change in the CLI; the prompt now renders in red instead of default terminal text.
♿ Accessibility: Improves visual distinction of critical destructive actions in the terminal interface.

---
*PR created automatically by Jules for task [15704044504439816815](https://jules.google.com/task/15704044504439816815) started by @EffortlessSteven*