### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL injection in StoreQuery ORDER BY

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-01-28 - SQL Injection in StoreQuery ORDER BY
+**Vulnerability:** The SQLite `ORDER BY` clause in `transcription/store/store.py` directly interpolated the user-controlled `query.order_by` field, allowing potential SQL injection.
+**Learning:** Standard SQLite parameterization (`?`) does not support dynamic column names in `ORDER BY` clauses. Direct interpolation must never be used on unsanitized input.
+**Prevention:** Always use a strict allowlist (e.g., `ALLOWED_ORDER_COLS`) to validate user-provided column names before string interpolation in SQL queries.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,7 +32,7 @@ include requirements-dev.txt
 
 # Typed package markers
 include transcription/py.typed
-include slower_whisper/py.typed
+include slower_whisper/*.py slower_whisper/py.typed
 
 # Docs and examples
 recursive-include docs *.md *.txt *.json *.py
@@ -79,3 +79,4 @@ prune whisper_json
 prune venv
 prune env
 prune .venv
+recursive-include slower_whisper *.py

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -921,7 +921,17 @@ class SQLiteConversationStore:
         # Order by
         order_col = "rank" if query.text else query.order_by
 
-        ALLOWED_ORDER_COLS = {"rank", "start_time", "end_time", "speaker_id", "segment_index", "speaker_confidence", "transcript_id", "file_name", "language"}
+        ALLOWED_ORDER_COLS = {
+            "rank",
+            "start_time",
+            "end_time",
+            "speaker_id",
+            "segment_index",
+            "speaker_confidence",
+            "transcript_id",
+            "file_name",
+            "language",
+        }
         if order_col not in ALLOWED_ORDER_COLS:
             order_col = "start_time"
 

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,11 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        ALLOWED_ORDER_COLS = {"rank", "start_time", "end_time", "speaker_id", "segment_index", "speaker_confidence", "transcript_id", "file_name", "language"}
+        if order_col not in ALLOWED_ORDER_COLS:
+            order_col = "start_time"
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The SQLite `ORDER BY` clause in `transcription/store/store.py` directly interpolated the user-controlled `query.order_by` field, allowing potential SQL injection.
🎯 Impact: An attacker could potentially inject malicious SQL commands via the `order_by` field, leading to unauthorized data access or database manipulation.
🔧 Fix: Implemented an explicit allowlist (`ALLOWED_ORDER_COLS`) to validate user-provided column names before string interpolation in the `ORDER BY` clause. Invalid column names safely fall back to the default `start_time`.
✅ Verification: Ran unit tests for the store using `uv run pytest tests/test_conversation_store.py`.

---
*PR created automatically by Jules for task [8600623943363071915](https://jules.google.com/task/8600623943363071915) started by @EffortlessSteven*