### PR TITLE
🎨 Palette: [UX improvement] Add warning for destructive actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-02-05 - Inconsistent Warning Formats for Destructive CLI Actions
+**Learning:** Destructive actions across different CLI commands (e.g., `cache --clear` vs `speaker-identity --delete`) can lack consistent visual warning weight. The `speaker-identity` command was missing the explicit red "This cannot be undone." warning used elsewhere.
+**Action:** Always use `Colors.red("This cannot be undone.")` inside interactive confirmation prompts for irreversible operations to maintain a consistent UX pattern for danger warnings.

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added the `Colors.red("This cannot be undone.")` warning to the interactive confirmation prompt for deleting a speaker in the CLI.
🎯 Why: To maintain consistent UX patterns for destructive, irreversible actions across the CLI (matching the behavior of the `cache --clear` command), ensuring users are clearly warned before proceeding.
📸 Before/After: Visual change in CLI (red text is now displayed).
♿ Accessibility: N/A

---
*PR created automatically by Jules for task [18363391970196542255](https://jules.google.com/task/18363391970196542255) started by @EffortlessSteven*