### PR TITLE
🎨 Palette: Add destructive action warning for speaker deletion

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
**💡 What:** Added a clear, red-colored warning ("This cannot be undone.") to the interactive prompt when deleting a speaker identity.
**🎯 Why:** Users were likely missing the plain text prompt for this destructive action, which could lead to accidental deletion of valuable mapped speaker identities. This follows the codebase's existing UX paradigm for cache clearing.
**📸 Before/After:** N/A (CLI visual enhancement only).
**♿ Accessibility:** N/A (The prompt now provides stronger semantic warning via color while remaining a standard terminal string, which screen readers will still read normally).

---
*PR created automatically by Jules for task [5944319920599353318](https://jules.google.com/task/5944319920599353318) started by @EffortlessSteven*