### PR TITLE
🎨 Palette: [UX improvement] Add clear warning to destructive speaker deletion prompt

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,7 +1563,10 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        from .color_utils import Colors
+
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
* 💡 What: Added a clear, red-colored warning ("This cannot be undone.") to the interactive prompt when deleting a speaker profile via the CLI.
* 🎯 Why: Deleting a speaker is a destructive action. The `.jules/palette.md` journal dictates that such actions require distinct visual warnings using alert colors to prevent accidental data loss.
* 📸 Before/After: Visual change in CLI interactive prompt.
* ♿ Accessibility: Improves cognitive accessibility by clearly distinguishing the dangerous nature of the action with standard alert colors, enforcing attention.

---
*PR created automatically by Jules for task [16236553953452670313](https://jules.google.com/task/16236553953452670313) started by @EffortlessSteven*