### PR TITLE
🎨 Palette: [UX improvement] Add red visual warning to destructive speaker deletion

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        prompt_text = f"Delete speaker '{speaker.name}' ({speaker.id})?"
+        confirm = input(f"{Colors.red(prompt_text)} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
**💡 What**: Added `Colors.red` styling to the speaker deletion confirmation prompt.
**🎯 Why**: Destructive actions (like permanently deleting a registered speaker profile) require distinct visual warnings to prevent accidental data loss. Plain text warnings are often missed by users quickly scanning CLI output. This change follows the guidance in `.jules/palette.md` to use red text for critical warnings.
**📸 Before/After**:
*Before:* `Delete speaker 'Alice' (SPEAKER_00)? [y/N]` (default terminal text color)
*After:* `Delete speaker 'Alice' (SPEAKER_00)? [y/N]` (the main prompt text is colored red)
**♿ Accessibility**: Improves cognitive accessibility and prevents errors by providing a strong visual cue for a destructive action.

---
*PR created automatically by Jules for task [474062428494585904](https://jules.google.com/task/474062428494585904) started by @EffortlessSteven*