### PR TITLE
🎨 Palette: [UX improvement] Add clear warnings for destructive actions

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added a clear warning using `Colors.red` to the speaker deletion confirmation prompt in `transcription/speaker_identity.py`.
🎯 Why: Deleting a speaker profile is a destructive action that cannot be undone. Users need distinct visual warnings to prevent accidental data loss. Plain text warnings are often missed.
♿ Accessibility: N/A (CLI change)

---
*PR created automatically by Jules for task [6602926062021602145](https://jules.google.com/task/6602926062021602145) started by @EffortlessSteven*