### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in search order_by clause

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-04-19 - SQL Injection in SQLiteConversationStore
+**Vulnerability:** SQL injection vulnerability in `transcription/store/store.py` where user-provided `order_by` string is directly interpolated into SQL query.
+**Learning:** Even internal API query models (`StoreQuery`) can be attack vectors if they pass unsanitized strings directly into database operations. Specifically, SQLite `ORDER BY` allows arbitrary SQL execution if the column name is directly injected.
+**Prevention:** Use an explicit dictionary-based allowlist to map user-facing column names to safe SQL table aliases instead of direct string interpolation.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,12 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+
+def test_search_sql_injection_prevention(store: ConversationStore) -> None:
+    """Test that invalid order_by columns raise QueryError."""
+    from transcription.store.types import QueryError
+
+    query = StoreQuery(order_by="invalid_column_name")
+    with pytest.raises(QueryError):
+        store.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -919,7 +919,26 @@ class SQLiteConversationStore:
                 params.append(query.date_range.before)
 
         # Order by
-        order_col = "rank" if query.text else query.order_by
+        ALLOWED_ORDER_COLS = {
+            "segment_id": "s.id",
+            "transcript_id": "s.transcript_id",
+            "segment_index": "s.segment_index",
+            "start_time": "s.start_time",
+            "end_time": "s.end_time",
+            "text": "s.text",
+            "speaker_id": "s.speaker_id",
+            "speaker_confidence": "s.speaker_confidence",
+            "file_name": "t.file_name",
+            "language": "t.language",
+            "rank": "rank",
+        }
+        if query.text:
+            order_col = "rank"
+        else:
+            if query.order_by not in ALLOWED_ORDER_COLS:
+                raise QueryError(f"Invalid order_by column: {query.order_by}")
+            order_col = ALLOWED_ORDER_COLS[query.order_by]
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SQL injection vulnerability in `transcription/store/store.py` where user-provided `order_by` strings were directly interpolated into the SQL query without sanitization.
🎯 Impact: Attackers could execute arbitrary blind SQL injection attacks by injecting SQL code via the `order_by` parameter, potentially exfiltrating sensitive data or modifying database state.
🔧 Fix: Replaced direct string interpolation with a strict dictionary-based allowlist. Invalid `order_by` columns now explicitly raise a `QueryError`.
✅ Verification: Added a dedicated unit test in `tests/test_conversation_store.py` that verifies `QueryError` is raised on invalid input. Run `uv run pytest tests/test_conversation_store.py` to confirm.

---
*PR created automatically by Jules for task [17062995998517211940](https://jules.google.com/task/17062995998517211940) started by @EffortlessSteven*