### PR TITLE
🎨 Palette: Bypass empty cache warning prompt

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -786,6 +786,12 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
         elif args.clear == "samples":
             targets = [("Samples", samples_dir)]
 
+        total_size = sum(_get_cache_size(path) for _, path in targets)
+
+        if total_size == 0:
+            print(f"Cache '{args.clear}' is already empty.")
+            return 0
+
         if not args.force:
             if not sys.stdin.isatty():
                 print(
@@ -795,8 +801,6 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
                 )
                 return 1
 
-            # Only calculate size when prompting (skip expensive traversal when --force)
-            total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
             confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")


### PR DESCRIPTION
*   💡 What: Bypass the interactive confirmation prompt when attempting to clear an already empty cache.
*   🎯 Why: To improve UX by not making users confirm a destructive action that will effectively be a no-op.
*   ♿ Accessibility: N/A

---
*PR created automatically by Jules for task [8184891023588689145](https://jules.google.com/task/8184891023588689145) started by @EffortlessSteven*