### PR TITLE
🎨 Palette: [UX improvement] Bypass cache warning for empty caches

### DIFF
--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -34,6 +34,7 @@ class TestCacheClearConfirmation:
             patch("shutil.rmtree") as mock_rmtree,
             patch("builtins.input", return_value="y") as mock_input,
             patch("sys.stdin.isatty", return_value=True),
+            patch("transcription.cli._get_cache_size", return_value=100),
         ):
             exit_code = main(["cache", "--clear", "whisper"])
 
@@ -49,6 +50,7 @@ class TestCacheClearConfirmation:
             patch("shutil.rmtree") as mock_rmtree,
             patch("builtins.input", return_value="n") as mock_input,
             patch("sys.stdin.isatty", return_value=True),
+            patch("transcription.cli._get_cache_size", return_value=100),
         ):
             exit_code = main(["cache", "--clear", "whisper"])
 

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -798,6 +798,10 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             # Only calculate size when prompting (skip expensive traversal when --force)
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
+            if total_size == 0:
+                print(f"Cache is already empty ({size_str}).")
+                return 0
+
             warning = Colors.red("This cannot be undone.")
             confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
             if confirm.lower() not in ("y", "yes"):


### PR DESCRIPTION
💡 **What:** 
- Added an early return when trying to clear a cache that is already empty (0 bytes).

🎯 **Why:** 
- When the cache is already empty, warning the user about a destructive action is a no-op that causes unnecessary friction and cognitive load.

📸 **Before/After:** 
- Before: `Clear all cache (0.0 B)? \033[91mThis cannot be undone.\033[0m [y/N]`
- After (Empty): `Cache is already empty (0.0 B).` (Immediate exit)

♿ **Accessibility:** 
- Reducing cognitive load by preventing meaningless prompts when no action is needed.

---
*PR created automatically by Jules for task [14577534838016612006](https://jules.google.com/task/14577534838016612006) started by @EffortlessSteven*