### PR TITLE
Remove ffmpeg dependency from enrichment tests; improve test isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     needs: [lint, format]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/tests/steps/test_enrichment_steps.py
+++ b/tests/steps/test_enrichment_steps.py
@@ -7,7 +7,6 @@ using pytest-bdd. Steps use the public API from transcription.api.
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 from typing import Any
 
@@ -24,15 +23,6 @@ from transcription import (
     EnrichmentError,
     enrich_directory,
     enrich_transcript,
-)
-
-# Check if ffmpeg is available
-FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
-
-# Load all scenarios from the feature file
-# Mark all scenarios as xfail if ffmpeg is not available since they require transcription
-pytestmark = pytest.mark.xfail(
-    not FFMPEG_AVAILABLE, reason="Requires ffmpeg for audio normalization", strict=False
 )
 
 scenarios("../features/enrichment.feature")

--- a/tests/steps/test_transcription_steps.py
+++ b/tests/steps/test_transcription_steps.py
@@ -22,13 +22,11 @@ from pytest_bdd import given, parsers, scenarios, then, when  # noqa: E402
 
 from transcription import TranscriptionConfig, transcribe_directory, transcribe_file
 
-# Check if ffmpeg is available
+# Check if ffmpeg is available — transcription BDD tests require audio normalization
 FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
 
-# Load all scenarios from the feature file
-# Mark all scenarios as xfail if ffmpeg is not available since they require audio normalization
-pytestmark = pytest.mark.xfail(
-    not FFMPEG_AVAILABLE, reason="Requires ffmpeg for audio normalization", strict=False
+pytestmark = pytest.mark.skipif(
+    not FFMPEG_AVAILABLE, reason="Requires ffmpeg for audio normalization"
 )
 
 scenarios("../features/transcription.feature")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,7 @@ Test coverage targets:
 from __future__ import annotations
 
 import json
+import os
 import struct
 import wave
 from pathlib import Path
@@ -802,6 +803,7 @@ class TestSaveTranscript:
         assert "old" not in data
         assert data["file"] == "test.wav"
 
+    @pytest.mark.skipif(os.getuid() == 0, reason="Permission tests don't work as root")
     def test_save_permission_error(self, simple_transcript: Transcript, tmp_path: Path) -> None:
         """Test save_transcript handles permission errors."""
         # Create read-only directory

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -15,6 +15,7 @@ Tests use pytest fixtures and mocking to avoid requiring actual GPU/models.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -1520,6 +1521,7 @@ def test_load_transcript_invalid_json(tmp_path):
         load_transcript(invalid_json)
 
 
+@pytest.mark.skipif(os.getuid() == 0, reason="Permission tests don't work as root")
 def test_save_transcript_to_readonly_location(test_transcript, tmp_path):
     """Test save_transcript handles permission errors."""
     # Create a read-only directory

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -41,6 +41,13 @@ from transcription.pipeline import (
 # ============================================================================
 
 
+@pytest.fixture(autouse=True)
+def _mock_normalize_all():
+    """Bypass ffmpeg-dependent audio normalization in all pipeline tests."""
+    with patch("transcription.audio_io.normalize_all"):
+        yield
+
+
 @pytest.fixture
 def temp_project_structure(tmp_path: Path) -> Paths:
     """


### PR DESCRIPTION
## What changed
- Removed ffmpeg availability check and xfail marker from enrichment BDD tests (`test_enrichment_steps.py`)
- Changed transcription BDD tests (`test_transcription_steps.py`) from `xfail` to `skipif` for ffmpeg availability
- Added autouse fixture in `test_pipeline.py` to mock `normalize_all()` and bypass ffmpeg dependency in all pipeline tests
- Added `skipif` markers to permission-based tests in `test_api.py` and `test_api_integration.py` to skip when running as root
- Updated GitHub Actions checkout action from v4 to v6

## Why
- **Test isolation:** Enrichment tests don't actually require ffmpeg; removing the marker prevents false failures
- **Better test semantics:** Using `skipif` instead of `xfail` for ffmpeg tests provides clearer intent (skip entirely vs. expect failure)
- **Reduced external dependencies:** Mocking audio normalization in pipeline tests removes hard ffmpeg requirement from CI
- **Root user handling:** Permission tests fail when running as root (e.g., in containers); skip them explicitly rather than failing
- **Action update:** v6 is the current stable version with security improvements

## How to review
- **Focus:** Test infrastructure and dependency handling
- **Key files:** 
  - `tests/steps/test_enrichment_steps.py` (removed ffmpeg check)
  - `tests/steps/test_transcription_steps.py` (xfail → skipif)
  - `tests/test_pipeline.py` (new mock fixture)
  - `tests/test_api.py`, `tests/test_api_integration.py` (root user skip markers)
- **Out of scope:** Actual ffmpeg functionality; this is purely test infrastructure

## How to validate (local)
```bash
./scripts/ci-local.sh fast
```

## Known limits / follow-ups
- N/A

## Checklist

- [ ] I have run `./scripts/ci-local.sh fast` and all checks pass locally
- [ ] My code follows the project's style guidelines
- [ ] I have updated documentation as needed
- [ ] This PR introduces no breaking changes to public API, CLI, or JSON schema

https://claude.ai/code/session_017PmbGCA9yHWt74K2EHpor6