### PR TITLE
🎨 Palette: Explicitly color choices in interactive confirmation prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-02-15 - Visualizing Destructive Choices
+**Learning:** In CLI confirmation prompts, visually coloring options (like red 'y' vs green 'N') effectively reinforces safe versus destructive choices for users.
+**Action:** Explicitly color prompt choices (e.g. `[{Colors.red('y')}/{Colors.green('N')}]`) in interactive confirmation prompts for destructive operations.

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,8 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            choices = f"[{Colors.red('y')}/{Colors.green('N')}]"
+            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} {choices} ")
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +873,8 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                choices = f"[{Colors.red('y')}/{Colors.green('N')}]"
+                confirm = input(f"{Colors.red('Overwrite?')} {choices} ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
**💡 What:** Added explicit `Colors.red` and `Colors.green` styling to the `[y/N]` confirmation choices in the `cache --clear` and `samples copy` commands.
**🎯 Why:** Enhances micro-UX by visually distinguishing the safe versus destructive choices in the prompts, reducing the likelihood of accidental destructive actions.
**📸 Before/After:** N/A (CLI visual change).
**♿ Accessibility:** Improves cognitive accessibility by providing color-coded visual cues alongside textual characters to indicate risk.

---
*PR created automatically by Jules for task [7673459717096362367](https://jules.google.com/task/7673459717096362367) started by @EffortlessSteven*