### PR TITLE
🎨 Palette: Colorize destructive confirmation prompts

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,8 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            options = f"[{Colors.red('y')}/{Colors.green('N')}]"
+            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} {options} ")
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +873,8 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                options = f"[{Colors.red('y')}/{Colors.green('N')}]"
+                confirm = input(f"{Colors.red('Overwrite?')} {options} ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
💡 **What:** Enhanced CLI interactive prompts for destructive actions (`cache --clear` and `samples copy` overwrites) to explicitly color the options as `[{Colors.red('y')}/{Colors.green('N')}]`.
🎯 **Why:** To visually reinforce safe versus destructive choices and provide a micro-UX improvement that enforces attention before taking irreversible actions.
📸 **Before/After:** Not applicable (CLI output, no visual screenshots available).
♿ **Accessibility:** Provides clear visual cues via color (and text case) to distinguish between confirming and aborting critical actions.

---
*PR created automatically by Jules for task [4083180081997365799](https://jules.google.com/task/4083180081997365799) started by @EffortlessSteven*