### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in search ORDER BY clause

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2025-10-25 - SQL Injection in ORDER BY Clause
+**Vulnerability:** SQL Injection in `ConversationStore.search()` via `StoreQuery.order_by` where unsanitized user input was interpolated directly into the `ORDER BY` clause string.
+**Learning:** Parameterized queries (`?`) cannot be used for column names or table names in SQL. Consequently, any dynamic `ORDER BY` column must be strictly validated against an allowlist before string interpolation.
+**Prevention:** Use an exact string match allowlist for all permissible column names (including table aliases) when constructing `ORDER BY` clauses dynamically.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,22 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+def test_search_order_by_sql_injection() -> None:
+    """Test that order_by is validated and prevents SQL injection."""
+    from transcription.store.store import ConversationStore
+    from transcription.store.types import StoreQuery
+
+    store = ConversationStore(":memory:")
+
+    # Attempt SQL injection
+    malicious_order_by = "start_time; DROP TABLE segments; --"
+    query = StoreQuery(order_by=malicious_order_by)
+
+    # Should not raise SQL error, but fallback to start_time
+    results = store.search(query)
+    assert isinstance(results, list)
+
+    # Check that table still exists
+    cursor = store._conn.execute("SELECT count(*) FROM segments")
+    assert cursor.fetchone()[0] == 0

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -919,7 +919,29 @@ class SQLiteConversationStore:
                 params.append(query.date_range.before)
 
         # Order by
+        allowed_columns = {
+            "rank",
+            "start_time",
+            "s.start_time",
+            "end_time",
+            "s.end_time",
+            "segment_index",
+            "s.segment_index",
+            "speaker_confidence",
+            "s.speaker_confidence",
+            "file_name",
+            "t.file_name",
+            "language",
+            "t.language",
+            "id",
+            "s.id",
+            "transcript_id",
+            "s.transcript_id",
+        }
         order_col = "rank" if query.text else query.order_by
+        if order_col not in allowed_columns:
+            order_col = "s.start_time"
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SQL Injection in `ConversationStore.search()` via `StoreQuery.order_by` where unsanitized user input was interpolated directly into the `ORDER BY` clause string.
🎯 Impact: An attacker could execute arbitrary SQL queries, leading to data exfiltration, modification, or deletion (e.g., dropping tables).
🔧 Fix: Implemented an explicit allowlist for valid column names (including table aliases) to strictly validate `order_by` values before string interpolation.
✅ Verification: Added `test_search_order_by_sql_injection` to ensure malicious payloads are safely rejected and fallback logic works as expected. Ran `pytest tests/test_conversation_store.py` which passes successfully.

---
*PR created automatically by Jules for task [1585597814793848162](https://jules.google.com/task/1585597814793848162) started by @EffortlessSteven*