### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in ORDER BY clause

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2025-05-02 - SQLite FTS5 ORDER BY SQL Injection
+**Vulnerability:** The `order_by` property of `StoreQuery` was directly concatenated into the `ConversationStore.search()` SQLite query: `f"ORDER BY {order_col} {order_dir}"`.
+**Learning:** In standard SQL implementations, including SQLite, `ORDER BY` clauses cannot be parameterized safely. Using dynamic field names directly from user/API input introduces a vulnerability where attackers can inject arbitrary subqueries or manipulate sort logic.
+**Prevention:** Always use a strict, hardcoded allowlist to validate user-supplied column names before using them in dynamic `ORDER BY` or `GROUP BY` clauses.

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,23 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        ALLOWED_ORDER_COLS = {
+            "rank",
+            "s.start_time",
+            "start_time",
+            "s.end_time",
+            "end_time",
+            "s.segment_index",
+            "segment_index",
+            "s.speaker_confidence",
+            "speaker_confidence",
+            "t.ingested_at",
+            "ingested_at",
+        }
+        if order_col not in ALLOWED_ORDER_COLS:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `order_by` field in `StoreQuery` was directly concatenated into the SQL `ORDER BY` clause in `ConversationStore.search()`. This allows attackers to execute arbitrary SQL subqueries or manipulate the query logic (SQL injection).
🎯 Impact: An attacker could potentially extract sensitive data from the database using error-based or time-based SQL injection, or cause a denial of service by executing expensive queries.
🔧 Fix: Added a strict allowlist validation for the `order_by` column. Only explicitly permitted column names and their table aliases are allowed. If an invalid column is provided, a `QueryError` is raised.
✅ Verification: Created a test script `test_sql_injection_order_by.py` that attempts to inject a subquery `(SELECT rank)` into the `order_by` field. Verified that the search is now blocked and successfully raises a `QueryError`. Also ran the existing test suite (`uv run pytest tests/test_conversation_store.py`) to ensure no regressions in legitimate sorting behavior. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [9115135357528112738](https://jules.google.com/task/9115135357528112738) started by @EffortlessSteven*