### PR TITLE
🎨 Palette: Colorize destructive CLI confirmation options

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,9 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            y_opt = Colors.red("y")
+            n_opt = Colors.green("N")
+            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [{y_opt}/{n_opt}] ")
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +874,9 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                y_opt = Colors.red("y")
+                n_opt = Colors.green("N")
+                confirm = input(f"{Colors.red('Overwrite?')} [{y_opt}/{n_opt}] ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
**💡 What:** Added red/green coloring to the `[y/N]` options in destructive CLI prompts (`cache clear` and file overwrite).
**🎯 Why:** To visually reinforce the safe vs. destructive choice, making the consequence of "y" more apparent to users.
**📸 Before/After:** Prompts previously ended with `[y/N]`. Now they end with `[y/N]` where 'y' is colored red and 'N' is colored green.
**♿ Accessibility:** Enhances visual communication of destructive actions for CLI users without screen readers by mapping danger to color conventions, alongside the existing warning text.

---
*PR created automatically by Jules for task [17038339386175576432](https://jules.google.com/task/17038339386175576432) started by @EffortlessSteven*