### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in search ORDER BY

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2024-05-24 - Prevent SQL Injection in Dynamic ORDER BY
+**Vulnerability:** Dynamic ORDER BY clause in ConversationStore search allowed SQL injection via string formatting.
+**Learning:** User input should never be interpolated into an ORDER BY clause. Prepared statements cannot parameterize column names in ORDER BY.
+**Prevention:** Always use a strict, hardcoded string exact-match allowlist for sorting columns and aliases.

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,30 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        # Security fix: Prevent SQL injection by validating order_col against an exact allowlist
+        allowed_order_cols = {
+            "s.id",
+            "s.transcript_id",
+            "s.segment_index",
+            "s.start_time",
+            "s.end_time",
+            "s.text",
+            "s.speaker_id",
+            "s.speaker_confidence",
+            "t.file_name",
+            "t.language",
+            "rank",
+            "start_time",
+            "end_time",
+            "segment_index",
+            "id",
+            "transcript_id"
+        }
+
+        if order_col not in allowed_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
## 🚨 Severity: CRITICAL
## 💡 Vulnerability: SQL Injection via ORDER BY
The `StoreQuery.order_by` field was directly interpolated into the SQL `ORDER BY` clause in `ConversationStore.search()`.

## 🎯 Impact:
An attacker could pass arbitrary SQL statements or exfiltrate data by injecting subqueries into the `order_by` parameter.

## 🔧 Fix: 
Implemented a strict allowlist of exact column names and table aliases for the `order_col`. Throws `QueryError` on invalid input.

## ✅ Verification: 
Ran `uv run pytest tests/test_conversation_store.py` successfully.

---
*PR created automatically by Jules for task [11862496891005535508](https://jules.google.com/task/11862496891005535508) started by @EffortlessSteven*