### PR TITLE
🎨 Palette: Colorize interactive confirmation prompts

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,9 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            y_opt = Colors.red('y')
+            n_opt = Colors.green('N')
+            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [{y_opt}/{n_opt}] ")
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +874,9 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                y_opt = Colors.red('y')
+                n_opt = Colors.green('N')
+                confirm = input(f"{Colors.red('Overwrite?')} [{y_opt}/{n_opt}] ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,7 +1563,10 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        from .color_utils import Colors
+        y_opt = Colors.red('y')
+        n_opt = Colors.green('N')
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [{y_opt}/{n_opt}] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added colored options to interactive confirmation prompts across the CLI (e.g. `[y/N]` becomes `[y(red)/N(green)]`).
🎯 Why: Destructive actions like deleting speakers or clearing the cache require distinct visual warnings. Plain text warnings are often missed. Coloring the options visually reinforces safe versus destructive choices.
📸 Before/After: The prompt options `[y/N]` are now colored to highlight the destructiveness of the "y" option.
♿ Accessibility: Enhances cognitive accessibility by adding clear color cues to critical decisions, reducing the likelihood of accidental destructive actions.

---
*PR created automatically by Jules for task [4685001843523696637](https://jules.google.com/task/4685001843523696637) started by @EffortlessSteven*