### PR TITLE
🎨 Palette: Color-coded safe vs. destructive confirmation prompts

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,9 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            y_opt = Colors.red("y")
+            n_opt = Colors.green("N")
+            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [{y_opt}/{n_opt}] ")
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +874,9 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                y_opt = Colors.red("y")
+                n_opt = Colors.green("N")
+                confirm = input(f"{Colors.red('Overwrite?')} [{y_opt}/{n_opt}] ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1551,6 +1551,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
     """Handle the delete subcommand."""
     import sys
 
+    from transcription.color_utils import Colors
+
     # Check if speaker exists
     speaker = registry.get_speaker(args.speaker_id)
     if speaker is None:
@@ -1563,7 +1565,9 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        y_opt = Colors.red("y")
+        n_opt = Colors.green("N")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [{y_opt}/{n_opt}] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
### 💡 What
Added color coding to the `[y/N]` confirmation options for destructive CLI prompts (like cache clearing, sample overwrite and deleting speakers). The 'y' (destructive) option is colored red, and the 'N' (safe/default) option is colored green.

### 🎯 Why
It visually reinforces the consequences of the action. By explicitly coloring the options, users are given an additional visual cue about which choice is safe versus destructive, reducing the likelihood of accidental data loss.

### 📸 Before/After
Before: `Clear whisper cache (10.5 MB)? This cannot be undone. [y/N]`
After: `Clear whisper cache (10.5 MB)? This cannot be undone. [y/N]` (with 'y' in red and 'N' in green)

### ♿ Accessibility
Improves micro-UX by visually distinguishing safe and destructive choices in interactive prompts.

---
*PR created automatically by Jules for task [1744142855619412746](https://jules.google.com/task/1744142855619412746) started by @EffortlessSteven*