### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in search ORDER BY

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2026-02-05 - SQL Injection in Dynamic ORDER BY Clauses
+**Vulnerability:** SQL injection vulnerability in the `SQLiteConversationStore.search()` method due to unsanitized interpolation of the `order_by` parameter.
+**Learning:** Prepared statements (parameterized queries) cannot parameterize column names or `ORDER BY` directions. If `order_by` is concatenated into a SQL string directly from user input, attackers can inject subqueries or case statements to exfiltrate data, bypass checks, or cause denial of service.
+**Prevention:** Implement a strict, hardcoded exact-match string allowlist for all permitted sorting columns and aliases before concatenating them into the SQL query string. Raise an error if the input does not match the allowlist.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,31 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+
+def test_search_order_by_sql_injection():
+    """Test that order_by parameter is sanitized against SQL injection."""
+    import pytest
+
+    from transcription.store.store import SQLiteConversationStore
+    from transcription.store.types import StoreQuery
+
+    store = SQLiteConversationStore.open(":memory:")
+
+    # Insert a dummy record
+    store._conn.execute(
+        "INSERT INTO transcripts (transcript_id, file_name, ingested_at) VALUES ('t1', 'f1', '2023-01-01')"
+    )
+    store._conn.execute(
+        "INSERT INTO segments (id, transcript_id, segment_index, start_time, end_time, text, speaker_id) VALUES (1, 't1', 0, 0, 1, 'hello', 's1')"
+    )
+
+    # Valid column name
+    query = StoreQuery(order_by="start_time")
+    results = store.search(query)
+    assert len(results) > 0
+
+    # SQL injection attempt
+    query = StoreQuery(order_by="CASE WHEN 1=1 THEN abs(-9223372036854775808) ELSE start_time END")
+    with pytest.raises(Exception, match="Invalid order_by column"):
+        store.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,33 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        # Prevent SQL injection in order_by
+        allowed_order_cols = {
+            "rank",
+            "start_time",
+            "end_time",
+            "speaker_confidence",
+            "id",
+            "segment_index",
+            "speaker_id",
+            "text",
+            "file_name",
+            "language",
+            "s.start_time",
+            "s.end_time",
+            "s.speaker_confidence",
+            "s.id",
+            "s.segment_index",
+            "s.speaker_id",
+            "s.text",
+            "t.file_name",
+            "t.language",
+            "segment_id",
+        }
+        if order_col not in allowed_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `SQLiteConversationStore.search()` method suffered from a SQL injection vulnerability because the `order_by` query field was directly formatted into the SQL query without prior sanitization or validation. This allowed executing arbitrary SQL functions or subqueries within the `ORDER BY` clause.
🎯 Impact: An attacker could exploit this vulnerability to perform blind SQL injection by executing subqueries within a `CASE` statement, potentially exfiltrating sensitive data or causing a denial of service (DoS) by executing expensive computations.
🔧 Fix: Implemented an exact-match allowlist check for the `order_by` parameter, ensuring only safe, predefined column names (`rank`, `start_time`, `end_time`, `speaker_confidence`, `id`, `segment_index`, `speaker_id`, etc. including aliases) are accepted, throwing a `QueryError` otherwise.
✅ Verification: Run `uv run pytest tests/test_conversation_store.py` to confirm the new `test_search_order_by_sql_injection` passes and that a `QueryError` is raised with the correct message for invalid `order_by` values.

---
*PR created automatically by Jules for task [18254203857010268889](https://jules.google.com/task/18254203857010268889) started by @EffortlessSteven*