### PR TITLE
🎨 Palette: Colorize confirmation prompt options

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,9 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            y_opt = Colors.red("y")
+            n_opt = Colors.green("N")
+            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [{y_opt}/{n_opt}] ")
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +874,9 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                y_opt = Colors.red("y")
+                n_opt = Colors.green("N")
+                confirm = input(f"{Colors.red('Overwrite?')} [{y_opt}/{n_opt}] ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
💡 **What:** Colored the `[y/N]` options in CLI confirmation prompts, explicitly highlighting `y` in red and `N` in green.
🎯 **Why:** To visually reinforce the consequences of the choices, making safe actions obvious and destructive ones clear.
♿ **Accessibility:** Improved visual clarity by distinguishing options with color for confirmation inputs.

---
*PR created automatically by Jules for task [16481926572562939481](https://jules.google.com/task/16481926572562939481) started by @EffortlessSteven*