### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in search ORDER BY clause

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2026-01-29 - SQL Injection in ORDER BY
+**Vulnerability:** SQL injection vulnerability in `ConversationStore.search()` where the `ORDER BY` clause was constructed using unvalidated string interpolation of the user-provided `query.order_by` value.
+**Learning:** SQL parameterization (using `?` or `%s`) only works for data values, not for identifiers like column names, table names, or SQL keywords. When dynamic sorting is required, standard parameterization is ineffective and unvalidated string formatting creates critical SQL injection risks.
+**Prevention:** Never use direct string interpolation for dynamic SQL columns. Always use a strict, hardcoded exact-match string allowlist to validate user-provided sort options before formatting them into queries.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,12 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+
+def test_search_sql_injection_order_by() -> None:
+    store = ConversationStore(":memory:")
+    query = StoreQuery(order_by="start_time; DROP TABLE segments; --")
+    from transcription.store import QueryError
+
+    with pytest.raises(QueryError, match="Invalid order_by column"):
+        store.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,20 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        # Prevent SQL injection by strict allowlist for order_by columns
+        allowed_order_cols = {
+            "start_time",
+            "end_time",
+            "speaker_confidence",
+            "s.start_time",
+            "s.end_time",
+            "s.speaker_confidence",
+            "rank",
+        }
+        if order_col not in allowed_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: SQL injection vulnerability found in `ConversationStore.search()` where the `ORDER BY` clause was constructed using unvalidated string interpolation of user input.
🎯 **Impact**: Allowed arbitrary SQL execution or data leakage through manipulated `order_by` values.
🔧 **Fix**: Implemented a strict hardcoded allowlist for valid column aliases in the `ORDER BY` clause, raising a `QueryError` for unexpected inputs.
✅ **Verification**: Added `test_search_sql_injection_order_by` unit test that triggers a `QueryError` when attempting to pass SQL statements into `order_by`.

---
*PR created automatically by Jules for task [4119998017932780582](https://jules.google.com/task/4119998017932780582) started by @EffortlessSteven*