### PR TITLE
🎨 Palette: Add explicit colored confirmation to speaker delete prompt

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-02-15 - Explicit Action Confirmation Colors
+**Learning:** For CLI applications, a simple but effective micro-UX improvement is to explicitly color the options in confirmation prompts (e.g., `[{Colors.red('y')}/{Colors.green('N')}]`) to visually reinforce safe versus destructive choices.
+**Action:** Always color prompt options for destructive commands, combining with a clear warning.

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1557,13 +1557,20 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
         print(f"Speaker not found: {args.speaker_id}", file=sys.stderr)
         return 1
 
+    from .color_utils import Colors
+
     # Confirm deletion
     if not args.force:
         if not sys.stdin.isatty():
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        y_opt = Colors.red("y")
+        n_opt = Colors.green("N")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(
+            f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [{y_opt}/{n_opt}] "
+        )
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
### 💡 What
Added explicit color coding for the `y/N` options and added a "This cannot be undone." warning in the `slower-whisper speaker delete` confirmation prompt.

### 🎯 Why
Deleting a speaker is a destructive action. Explicit color coding (red for yes, green for no) alongside a warning visually reinforces the impact of the action, reducing the likelihood of accidental deletions. Plain text warnings are often missed, as noted in previous UX learnings.

### 📸 Before/After
**Before:**
`Delete speaker 'John Doe' (speaker-123)? [y/N] ` (Plain text)

**After:**
`Delete speaker 'John Doe' (speaker-123)? This cannot be undone. [y/N] ` (With `This cannot be undone.` and `y` in red, `N` in green)

### ♿ Accessibility
Improves cognitive accessibility by providing immediate visual cues (color and text) about the destructiveness of the action.

---
*PR created automatically by Jules for task [17009729283909639331](https://jules.google.com/task/17009729283909639331) started by @EffortlessSteven*