### PR TITLE
⚡ Bolt: Combine np.percentile calls in audio_health.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-10 - Combine multiple np.percentile calls
+**Learning:** To optimize multiple `np.percentile` calculations on the same array in NumPy, combine them into a single call passing a list of percentiles (e.g., `np.percentile(array, [10, 90])`) to significantly reduce Python overhead and internal sorting passes.
+**Action:** Always check if multiple `np.percentile` calls on the same array can be combined into a single call.

--- a/transcription/audio_health.py
+++ b/transcription/audio_health.py
@@ -158,8 +158,8 @@ def _compute_snr_proxy(samples: np.ndarray) -> float:
     energy = samples**2
 
     # Get percentiles
-    high_energy = np.percentile(energy, _SNR_PERCENTILE_HIGH)
-    low_energy = np.percentile(energy, _SNR_PERCENTILE_LOW)
+    # ⚡ Bolt: Combine percentiles into a single numpy call to reduce Python overhead and sorting passes
+    low_energy, high_energy = np.percentile(energy, [_SNR_PERCENTILE_LOW, _SNR_PERCENTILE_HIGH])
 
     # Avoid division by zero and log of zero
     if low_energy < 1e-10:


### PR DESCRIPTION
💡 What: Combined multiple `np.percentile` calls on the same array into a single call in `_compute_snr_proxy` within `transcription/audio_health.py`.
🎯 Why: `np.percentile` has overhead due to input validation and internal sorting. Calling it multiple times on the same array is redundant.
📊 Impact: Reduces overhead by performing the sort and Python checks only once. This is expected to be measurably faster when calculating percentiles.
🔬 Measurement: The pytest suite has been verified. The test for the module, `tests/test_audio_health.py`, passes successfully, confirming functional equivalence.

---
*PR created automatically by Jules for task [5638170385261674525](https://jules.google.com/task/5638170385261674525) started by @EffortlessSteven*