### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in search query ORDER BY clause

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2024-05-10 - SQL Injection in ORDER BY Clause
+**Vulnerability:** Dynamic string interpolation in SQL `ORDER BY` clauses allows SQL injection.
+**Learning:** Parameterized queries (`?`) cannot be used to parameterize column names in `ORDER BY` clauses. Direct string interpolation was used, leaving the code vulnerable to injection.
+**Prevention:** Implement a strict, hardcoded exact-match string allowlist for all permitted sorting columns and aliases before interpolating them into the SQL query string.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,16 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+
+def test_search_sql_injection_order_by():
+    import pytest
+
+    from transcription.store import ConversationStore, StoreQuery
+    from transcription.store.types import QueryError
+
+    store = ConversationStore(":memory:")
+    # Test that an invalid order_by column raises QueryError
+    query = StoreQuery(order_by="(SELECT 1/0)")
+    with pytest.raises(QueryError, match="Invalid order_by column:"):
+        store.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,20 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        # Security: Prevent SQL injection in ORDER BY clause
+        allowed_order_cols = {
+            "start_time",
+            "end_time",
+            "segment_index",
+            "rank",
+            "speaker_id",
+            "transcript_id",
+            "speaker_confidence",
+        }
+        if order_col not in allowed_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `order_by` parameter from `StoreQuery` was directly interpolated into the SQL query's `ORDER BY` clause without validation, allowing SQL injection.
🎯 Impact: An attacker could execute arbitrary SQL statements by passing a malicious payload via the `order_by` parameter, potentially reading sensitive data or altering the database.
🔧 Fix: Implemented an exact-match string allowlist for permitted sorting columns (e.g., `start_time`, `rank`) in `transcription/store/store.py`. If an invalid column is provided, a `QueryError` is immediately raised.
✅ Verification: Added a unit test `test_search_sql_injection_order_by` in `tests/test_conversation_store.py` that verifies a `QueryError` is raised when an invalid `order_by` parameter is supplied.

---
*PR created automatically by Jules for task [5494556812904994461](https://jules.google.com/task/5494556812904994461) started by @EffortlessSteven*