### PR TITLE
🎨 Palette: Colorize destructive confirmation prompts options

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,9 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            y_opt = Colors.red("y")
+            n_opt = Colors.green("N")
+            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [{y_opt}/{n_opt}] ")
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +874,9 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                y_opt = Colors.red("y")
+                n_opt = Colors.green("N")
+                confirm = input(f"{Colors.red('Overwrite?')} [{y_opt}/{n_opt}] ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,9 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        y_opt = Colors.red("y")
+        n_opt = Colors.green("N")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [{y_opt}/{n_opt}] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
**What:** Added colors to confirmation prompt options for destructive actions (`cache --clear`, overwrite files, and `speaker delete`), making the `y` red (dangerous) and `N` green (safe fallback).

**Why:** To provide an intuitive micro-UX enhancement that helps users clearly see their choices, drawing attention to the finality and potential danger of these actions.

**Before/After:** The `[y/N]` text is now highlighted as `[` + `Colors.red('y')` + `/` + `Colors.green('N')` + `]`.

**Accessibility:** Enhances clarity through visual coding, which quickly communicates the risk of the 'yes' option while making the 'No' option more prominent as the default safe choice.

---
*PR created automatically by Jules for task [8776133020456995774](https://jules.google.com/task/8776133020456995774) started by @EffortlessSteven*