### PR TITLE
🎨 Palette: Add visual warning to speaker delete confirmation

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added a distinct visual warning to the destructive speaker delete confirmation prompt.
🎯 Why: Plain text warnings are often missed, especially for destructive actions like deleting a speaker profile.
♿ Accessibility: Improved visual contrast for critical warnings using `Colors.red()`.
📸 Before/After: N/A (CLI text output).

---
*PR created automatically by Jules for task [12776439093764846630](https://jules.google.com/task/12776439093764846630) started by @EffortlessSteven*