### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery order_by

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2026-05-12 - SQL Injection in StoreQuery order_by
+**Vulnerability:** SQL injection via the `order_by` field in `StoreQuery` due to direct string interpolation into the `ORDER BY` clause.
+**Learning:** Dynamic `ORDER BY` clauses cannot use parameterized queries (prepared statements).
+**Prevention:** Always implement a strict, hardcoded exact-match string allowlist for all permitted sorting columns and aliases.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -27,6 +27,7 @@ from transcription.store import (
     ExportFormat,
     ExportOptions,
     IngestOptions,
+    QueryError,
     QueryFilter,
     SpeakerQuery,
     StoreError,
@@ -1048,3 +1049,19 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+
+def test_sql_injection_order_by_invalid():
+    store = ConversationStore(":memory:")
+    query = StoreQuery(order_by="start_time; DROP TABLE transcripts;")
+    with pytest.raises(QueryError, match="Invalid order_by column"):
+        store.search(query)
+
+
+def test_sql_injection_order_by_valid():
+    store = ConversationStore(":memory:")
+    query = StoreQuery(order_by="start_time")
+    try:
+        store.search(query)
+    except QueryError:
+        pytest.fail("QueryError raised for valid order_by column")

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1060,6 +1060,7 @@ def test_sql_injection_order_by_invalid():
 
 def test_sql_injection_order_by_valid():
     store = ConversationStore(":memory:")
+    # The __init__ of ConversationStore takes care of creating the schema
     query = StoreQuery(order_by="start_time")
     try:
         store.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,28 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+        allowed_order_cols = {
+            "start_time",
+            "end_time",
+            "segment_index",
+            "speaker_confidence",
+            "rank",
+            "file_name",
+            "language",
+            "s.start_time",
+            "s.end_time",
+            "s.segment_index",
+            "s.speaker_confidence",
+            "t.file_name",
+            "t.language",
+            "text",
+            "s.text",
+            "speaker_id",
+            "s.speaker_id",
+        }
+        if order_col not in allowed_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -81,6 +81,27 @@ def get_default_store_path() -> Path:
     return store_dir / "store.db"
 
 
+ALLOWED_ORDER_COLS = frozenset([
+    "start_time",
+    "end_time",
+    "segment_index",
+    "speaker_confidence",
+    "rank",
+    "file_name",
+    "language",
+    "s.start_time",
+    "s.end_time",
+    "s.segment_index",
+    "s.speaker_confidence",
+    "t.file_name",
+    "t.language",
+    "text",
+    "s.text",
+    "speaker_id",
+    "s.speaker_id",
+])
+
+
 class SQLiteConversationStore:
     """SQLite-backed conversation store with FTS5 search.
 
@@ -920,26 +941,7 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
-        allowed_order_cols = {
-            "start_time",
-            "end_time",
-            "segment_index",
-            "speaker_confidence",
-            "rank",
-            "file_name",
-            "language",
-            "s.start_time",
-            "s.end_time",
-            "s.segment_index",
-            "s.speaker_confidence",
-            "t.file_name",
-            "t.language",
-            "text",
-            "s.text",
-            "speaker_id",
-            "s.speaker_id",
-        }
-        if order_col not in allowed_order_cols:
+        if order_col not in ALLOWED_ORDER_COLS:
             raise QueryError(f"Invalid order_by column: {order_col}")
 
         order_dir = "DESC" if query.order_desc else "ASC"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SQL injection was possible via the `order_by` parameter in `StoreQuery` because the parameter was directly interpolated into the query without validation.
🎯 Impact: An attacker could execute arbitrary SQL queries, leading to data exfiltration, database modification, or denial of service.
🔧 Fix: Implemented a strict allowlist of permitted columns and aliases for the `order_by` parameter, raising a `QueryError` if an invalid column is provided.
✅ Verification: Unit tests have been added to ensure invalid `order_by` clauses correctly raise a `QueryError` while valid ones execute successfully.

---
*PR created automatically by Jules for task [14338157426285949578](https://jules.google.com/task/14338157426285949578) started by @EffortlessSteven*