### PR TITLE
🎨 Palette: Add destructive action confirmation color

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added `Colors.red` warning to speaker deletion confirmation prompt.
🎯 Why: To visually warn users that deleting a speaker is a destructive action that cannot be undone.
📸 Before/After: Before it printed plain text `Delete speaker 'NAME' (ID)? [y/N]`. After, it prints `Delete speaker 'NAME' (ID)? \033[31mThis cannot be undone.\033[0m [y/N]` (red text in the terminal for the warning).
♿ Accessibility: Color contrast and explicit warning text support clear communication of irreversible actions.

---
*PR created automatically by Jules for task [1708822108276126634](https://jules.google.com/task/1708822108276126634) started by @EffortlessSteven*