### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery order_by

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-05-13 - SQL Injection in StoreQuery ORDER BY
+**Vulnerability:** The `StoreQuery` object in `transcription/store/store.py` allows arbitrary strings in the `order_by` field, which are directly concatenated into the SQL query's `ORDER BY` clause, allowing SQL injection.
+**Learning:** Even if primary query parameters are parameterized, dynamic `ORDER BY` clauses are vulnerable if they blindly concatenate user input, as prepared statements cannot parameterize column names.
+**Prevention:** Implement a strict, hardcoded string allowlist for all permitted sorting columns (including aliases) and validate `order_col` against it before execution.

--- a/tests/test_sqli_order_by.py
+++ b/tests/test_sqli_order_by.py
@@ -1,0 +1,15 @@
+import pytest
+
+from transcription.store.store import SQLiteConversationStore
+from transcription.store.types import QueryError, StoreQuery
+
+
+def test_sql_injection_order_by():
+    store = SQLiteConversationStore.open(":memory:")
+    # Initialize basic schema needed for the test
+    # (open already creates tables automatically now)
+
+    # Try a syntax error or malicious payload
+    query = StoreQuery(text=None, order_by="INVALID_COLUMN_OR_INJECTION")
+    with pytest.raises(QueryError, match="Invalid order_by column"):
+        store.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -64,6 +64,22 @@ from .types import (
     TranscriptSummary,
 )
 
+ALLOWED_ORDER_BY_COLUMNS: set[str] = {
+    "start_time",
+    "s.start_time",
+    "end_time",
+    "s.end_time",
+    "segment_index",
+    "s.segment_index",
+    "speaker_id",
+    "s.speaker_id",
+    "speaker_confidence",
+    "s.speaker_confidence",
+    "rank",
+    "id",
+    "s.id",
+}
+
 if TYPE_CHECKING:
     from ..models import Transcript
 
@@ -920,6 +936,9 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+        if order_col not in ALLOWED_ORDER_BY_COLUMNS:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SQL Injection vulnerability in `transcription/store/store.py` where the `StoreQuery`'s `order_by` field is directly concatenated into the SQL query without validation, allowing arbitrary SQL execution via subqueries or malicious column names.
🎯 Impact: A malicious user or script could inject arbitrary SQL to execute subqueries, infer database schema, or cause denial of service.
🔧 Fix: Implemented a strict allowlist (`ALLOWED_ORDER_BY_COLUMNS`) and validated `order_col` against it before appending to the `ORDER BY` clause. Raised `QueryError` on invalid inputs.
✅ Verification: Added `tests/test_sqli_order_by.py` to verify `QueryError` is thrown for invalid `order_by` values. Ran existing tests `tests/test_conversation_store.py` to ensure valid inputs still work. Updated Sentinel journal with learnings.

---
*PR created automatically by Jules for task [13290668348555374698](https://jules.google.com/task/13290668348555374698) started by @EffortlessSteven*