### PR TITLE
🎨 Palette: Add visual warning to speaker delete confirmation

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added a clear visual warning in red (`This cannot be undone.`) to the interactive prompt when deleting a speaker via the CLI.
🎯 Why: Destructive actions like deleting a speaker require distinct visual cues. Plain text warnings are often overlooked by users in the CLI. By highlighting the irreversible nature of the action in red, we enforce user attention and reduce accidental deletions.
♿ Accessibility: Improves cognitive accessibility by providing a clear, colored warning for a critical destructive action, adhering to the "check-then-act" pattern with heightened visibility.

---
*PR created automatically by Jules for task [2024466768492517879](https://jules.google.com/task/2024466768492517879) started by @EffortlessSteven*