### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery order_by

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2026-05-14 - Fix SQL injection in StoreQuery order_by
+**Vulnerability:** The `StoreQuery` `order_by` parameter was dynamically inserted into a SQL `ORDER BY` clause using f-strings, allowing an attacker to pass arbitrary SQL or perform blind SQL injection attacks.
+**Learning:** SQL databases cannot parameterize column names in `ORDER BY` clauses. Any user-supplied sorting field must be strictly validated before being added to a query string.
+**Prevention:** Implement a strict, hardcoded exact-match string allowlist for all permitted sorting columns and aliases whenever an `ORDER BY` clause depends on dynamic input.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,19 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+
+def test_search_order_by_sql_injection():
+    """Test that invalid order_by columns raise QueryError instead of executing."""
+    import pytest
+
+    from transcription.store import ConversationStore, StoreQuery
+    from transcription.store.types import QueryError
+
+    store = ConversationStore(":memory:")
+
+    # Try to order by an invalid column with SQL injection
+    query = StoreQuery(order_by="start_time; DROP TABLE segments; --")
+
+    with pytest.raises(QueryError, match="Invalid order_by column"):
+        store.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,17 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+        allowed_order_cols = {
+            "rank",
+            "start_time",
+            "end_time",
+            "segment_index",
+            "speaker_id",
+            "language",
+        }
+        if order_col not in allowed_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `order_by` parameter in `StoreQuery` was injected directly into the SQL query without validation, enabling blind and multiline SQL injection attacks.
🎯 Impact: An attacker could bypass application logic, steal sensitive database information, or execute arbitrary SQL commands by crafting malicious `order_by` inputs.
🔧 Fix: Implemented an explicit allowlist of valid sorting column names (`rank`, `start_time`, `end_time`, `segment_index`, `speaker_id`, `language`). If an invalid column is provided, a `QueryError` is immediately raised.
✅ Verification: Added a test case in `tests/test_conversation_store.py` that verifies `QueryError` is raised for invalid inputs. Successfully ran test suite locally.

---
*PR created automatically by Jules for task [16499062814515188569](https://jules.google.com/task/16499062814515188569) started by @EffortlessSteven*