### PR TITLE
🎨 Palette: Add a11y improvements to HTML export

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-06-08 - Accessible HTML Exports
+**Learning:** Generated HTML exports often lack basic accessibility landmarks and document language definitions, making them difficult for screen reader users to navigate.
+**Action:** Ensure all dynamically generated HTML documents include a `lang` attribute on the `<html>` element (derived from the data if possible) and wrap primary content in a `<main>` landmark.

--- a/transcription/exporters.py
+++ b/transcription/exporters.py
@@ -113,18 +113,20 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
     output_path.parent.mkdir(parents=True, exist_ok=True)
     parts: list[str] = [
         "<!doctype html>",
-        "<html>",
+        f'<html lang="{html.escape(transcript.language) if transcript.language else "en"}">',
         "<head>",
         '<meta charset="utf-8" />',
         "<title>Transcript</title>",
         "<style>",
         "body { font-family: system-ui, sans-serif; color: #222; margin: 24px; }",
+        "main { max-width: 800px; margin: 0 auto; }",
         ".turn { padding: 6px 10px; border-radius: 8px; margin-bottom: 8px; }",
         ".speaker { font-weight: 600; margin-right: 8px; }",
         ".time { color: #666; font-size: 0.9em; margin-right: 6px; }",
         "</style>",
         "</head>",
         "<body>",
+        "<main>",
         f"<h2>{html.escape(transcript.file_name)}</h2>",
     ]
     for row in rows:
@@ -138,7 +140,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
             f"<div>{html.escape(row['text'])}</div>"
             "</div>"
         )
-    parts.extend(["</body>", "</html>"])
+    parts.extend(["</main>", "</body>", "</html>"])
     output_path.write_text("\n".join(parts), encoding="utf-8")
 
 


### PR DESCRIPTION
* 💡 What: Added `lang` attribute to `<html>` tag and wrapped content in a `<main>` landmark.
* 🎯 Why: To make the exported HTML transcripts more accessible for screen reader users.
* 📸 Before/After: Not applicable (visual change is only a margin/max-width adjustment via `<main>`).
* ♿ Accessibility: Improved screen reader experience by adding document language and a primary content landmark.

---
*PR created automatically by Jules for task [4211632360033761178](https://jules.google.com/task/4211632360033761178) started by @EffortlessSteven*