### PR TITLE
🎨 Palette: Make doctor status strings bold

### DIFF
--- a/transcription/telemetry.py
+++ b/transcription/telemetry.py
@@ -867,10 +867,10 @@ def format_doctor_report(report: DoctorReport, use_color: bool = True) -> str:
 
     # Status symbols
     symbols = {
-        CheckStatus.PASS: (Colors.green("[PASS]") if use_color else "[PASS]"),
-        CheckStatus.WARN: (Colors.yellow("[WARN]") if use_color else "[WARN]"),
-        CheckStatus.FAIL: (Colors.red("[FAIL]") if use_color else "[FAIL]"),
-        CheckStatus.SKIP: (Colors.dim("[SKIP]") if use_color else "[SKIP]"),
+        CheckStatus.PASS: (Colors.bold(Colors.green("[PASS]")) if use_color else "[PASS]"),
+        CheckStatus.WARN: (Colors.bold(Colors.yellow("[WARN]")) if use_color else "[WARN]"),
+        CheckStatus.FAIL: (Colors.bold(Colors.red("[FAIL]")) if use_color else "[FAIL]"),
+        CheckStatus.SKIP: (Colors.bold(Colors.dim("[SKIP]")) if use_color else "[SKIP]"),
     }
 
     for check in report.checks:


### PR DESCRIPTION
- **What:** Use `Colors.bold` on the doctor status strings (`[PASS]`, `[WARN]`, `[FAIL]`, `[SKIP]`) in the `slower-whisper doctor` CLI output.
- **Why:** A micro-UX improvement to make the `doctor` command output easier and more pleasant to read by parsing visual status information more quickly.
- **Accessibility:** Visual contrast and hierarchy enhancement for standard terminal readouts.

---
*PR created automatically by Jules for task [7482002783848182266](https://jules.google.com/task/7482002783848182266) started by @EffortlessSteven*