### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery order_by

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-06-11 - SQL Injection in ORDER BY Clause
+**Vulnerability:** Unescaped string interpolation for `order_by` in `StoreQuery.search` (`sql_parts.append(f"ORDER BY {order_col} {order_dir}")`). Allowed arbitrary query modification, potentially exposing hidden columns or performing timing attacks.
+**Learning:** Even internal queries that don't directly handle web input can be vulnerable to SQL injection if input from a typed data model (like `StoreQuery`) allows arbitrary strings that are then directly concatenated into a SQL statement.
+**Prevention:** For SQL components that cannot be parameterized (like table/column names in `ORDER BY`), use a strict allowlist of predefined valid names. Reject unrecognized inputs immediately.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,18 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+def test_store_query_order_by_sql_injection():
+    from transcription.store.store import ConversationStore
+    from transcription.store.types import StoreQuery
+    import pytest
+
+    with ConversationStore(":memory:") as store:
+        # Valid column should work
+        query = StoreQuery(order_by="start_time")
+        store.search(query)  # Should not raise
+
+        # Invalid/malicious column should raise ValueError
+        with pytest.raises(ValueError, match="Invalid order_by column"):
+            query = StoreQuery(order_by="(SELECT 1)")
+            store.search(query)

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1049,10 +1049,12 @@ class TestParquetExport:
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
 
+
 def test_store_query_order_by_sql_injection():
+    import pytest
+
     from transcription.store.store import ConversationStore
     from transcription.store.types import StoreQuery
-    import pytest
 
     with ConversationStore(":memory:") as store:
         # Valid column should work

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -922,7 +922,14 @@ class SQLiteConversationStore:
         order_col = "rank" if query.text else query.order_by
 
         # Protect against SQL injection by validating the column name
-        allowed_columns = {"start_time", "end_time", "segment_index", "speaker_id", "speaker_confidence", "rank"}
+        allowed_columns = {
+            "start_time",
+            "end_time",
+            "segment_index",
+            "speaker_id",
+            "speaker_confidence",
+            "rank",
+        }
         if order_col not in allowed_columns:
             raise ValueError(f"Invalid order_by column: {order_col}")
 

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,12 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        # Protect against SQL injection by validating the column name
+        allowed_columns = {"start_time", "end_time", "segment_index", "speaker_id", "speaker_confidence", "rank"}
+        if order_col not in allowed_columns:
+            raise ValueError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `order_by` field in `StoreQuery.search` was being interpolated directly into the SQL query without validation or sanitization, creating a SQL injection vulnerability.
🎯 Impact: An attacker could execute arbitrary SQL by crafting a malicious string in `order_by`, allowing them to bypass logic, leak data via timing attacks, or read hidden columns.
🔧 Fix: Added an allowlist of permitted columns `{"start_time", "end_time", "segment_index", "speaker_id", "speaker_confidence", "rank"}` and explicitly validated the `order_by` value against it. Raises a `ValueError` if the column is disallowed.
✅ Verification: Unit test added in `tests/test_conversation_store.py` verifying that invalid columns correctly raise a `ValueError`. Executed the test suite to ensure no regressions.

---
*PR created automatically by Jules for task [6085237321440680242](https://jules.google.com/task/6085237321440680242) started by @EffortlessSteven*