### PR TITLE
🎨 Palette: Add visual warning for speaker delete confirmation

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
- 💡 What: Added a red visual warning ("This cannot be undone.") to the speaker deletion confirmation prompt.
- 🎯 Why: Destructive actions like deleting a speaker require distinct visual warnings. Plain text warnings are often missed.
- ♿ Accessibility: Improved cognitive accessibility by highlighting critical destructive actions.

---
*PR created automatically by Jules for task [3914360605706100032](https://jules.google.com/task/3914360605706100032) started by @EffortlessSteven*