### PR TITLE
🎨 Palette: Add clear visual warning for destructive speaker deletion

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added a distinct visual warning `Colors.red("This cannot be undone.")` to the interactive confirmation prompt when deleting a speaker profile.
🎯 Why: Destructive actions like deleting cross-session speaker profiles need explicit attention. A plain text prompt might be missed by users quickly scanning the terminal.
📸 Before/After: N/A (Terminal text color change)
♿ Accessibility: The red color emphasizes the critical nature of the prompt, aligning with established CLI conventions for destructive actions without adding clutter.

---
*PR created automatically by Jules for task [10875213161406724923](https://jules.google.com/task/10875213161406724923) started by @EffortlessSteven*