### PR TITLE
🎨 Palette: Add critical warning color for speaker deletion confirmation

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
**What**:
Added a red-colored warning "This cannot be undone." to the interactive speaker deletion confirmation prompt.

**Why**:
The `slower-whisper` speaker deletion action is destructive. Following UX learnings for CLI experiences, destructive actions should include a visually distinct, attention-grabbing warning so that users don't accidentally perform the action.

**Before/After**:
Before: `Delete speaker 'Speaker 1' (spk_0)? [y/N] `
After: `Delete speaker 'Speaker 1' (spk_0)? This cannot be undone. [y/N] ` (with "This cannot be undone." colored in red).

**Accessibility**:
Using `color_utils.Colors` correctly handles terminals with NO_COLOR set or terminals that don't support ANSI coloring, gracefully degrading to plain text without confusing formatting characters.

---
*PR created automatically by Jules for task [13725937176835364928](https://jules.google.com/task/13725937176835364928) started by @EffortlessSteven*