### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery order_by

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2025-02-12 - SQL Injection in StoreQuery order_by
+**Vulnerability:** SQL Injection in `ConversationStore.search()` where the `query.order_by` property is directly interpolated into a query string using `f"ORDER BY {order_col} {order_dir}"`.
+**Learning:** Always validate and allowlist dynamically provided order by columns before string interpolation in SQL queries, as user-provided ordering directives cannot easily be parameterized.
+**Prevention:** Strictly restrict acceptable `order_by` columns to a pre-defined set of valid keys (e.g. `start_time`, `end_time`, `speaker_id`).

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,15 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+
+def test_search_sql_injection():
+    """Test that searching with an invalid order_by column defaults to a safe column and does not execute SQL injection."""
+    from transcription.store.store import ConversationStore
+    from transcription.store.types import StoreQuery
+
+    with ConversationStore(":memory:") as store:
+        query = StoreQuery(order_by="(SELECT random())")
+        # Should fallback to start_time and run successfully without executing the injection
+        results = store.search(query)
+        assert isinstance(results, list)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -919,7 +919,17 @@ class SQLiteConversationStore:
                 params.append(query.date_range.before)
 
         # Order by
-        order_col = "rank" if query.text else query.order_by
+        allowed_order_cols = {
+            "start_time",
+            "end_time",
+            "speaker_id",
+            "speaker_confidence",
+            "rank",
+            "id",
+        }
+        order_col = query.order_by if query.order_by in allowed_order_cols else "start_time"
+        if query.text:
+            order_col = "rank"
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SQL Injection vulnerability in `ConversationStore.search()` where the `order_by` property was directly interpolated into the SQL query without validation.
🎯 Impact: An attacker could exploit this by passing an arbitrary SQL command in the `order_by` field (e.g. `"(SELECT random())"` or worse like subqueries triggering delays). 
🔧 Fix: Added strict allowlisting to validate the `order_by` parameter against known safe column names (`start_time`, `end_time`, `speaker_id`, `speaker_confidence`, `rank`, `id`).
✅ Verification: Added `test_search_sql_injection` to `tests/test_conversation_store.py` and ran `pytest` locally.

---
*PR created automatically by Jules for task [9981363828068337277](https://jules.google.com/task/9981363828068337277) started by @EffortlessSteven*