### PR TITLE
🎨 Palette: Add destructive warning to speaker delete prompt

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from .color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added a distinct visual warning ('This cannot be undone.') colored in red to the interactive prompt for deleting a speaker.
🎯 Why: Deleting a speaker is a destructive action. Plain text warnings are often missed. A red warning inside the interactive prompt enforces user attention.
📸 Before/After: Before, it was a plain text prompt: 'Delete speaker 'Bob' (ID)? [y/N]'. After, it includes a red warning: 'Delete speaker 'Bob' (ID)? This cannot be undone. [y/N]'
♿ Accessibility: Ensures that critical, non-reversible actions have clear, unambiguous warnings.

---
*PR created automatically by Jules for task [7981470919133178278](https://jules.google.com/task/7981470919133178278) started by @EffortlessSteven*