### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in search order_by clause

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-06-14 - Fix SQL injection in search order_by clause
+**Vulnerability:** SQL injection vulnerability in `ConversationStore.search()` where the `query.order_by` field was directly interpolated into the query string (`f"ORDER BY {order_col} {order_dir}"`).
+**Learning:** Dynamic column names in `ORDER BY` clauses cannot be parameterized using standard SQLite placeholders (`?`). Direct string concatenation enables attackers to execute arbitrary SQL or extract data via error-based injection.
+**Prevention:** Strictly enforce explicit allowlists for dynamic sorting columns to validate user input before constructing SQL queries.

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -920,6 +920,16 @@ class SQLiteConversationStore:
 
         # Order by
         order_col = "rank" if query.text else query.order_by
+
+        # Prevent SQL injection in order_by
+        allowed_order_cols = {
+            "start_time", "end_time", "speaker_id", "speaker_confidence",
+            "text", "segment_index", "transcript_id", "file_name",
+            "language", "rank", "id", "segment_id"
+        }
+        if order_col not in allowed_order_cols:
+            raise ValueError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SQL injection vulnerability in `ConversationStore.search()` where the `query.order_by` field was directly interpolated into the query string (`f"ORDER BY {order_col} {order_dir}"`).
🎯 Impact: Arbitrary query execution or data extraction via error-based SQL injection. Dynamic column names in `ORDER BY` clauses cannot be parameterized using standard SQLite placeholders (`?`).
🔧 Fix: Added an explicit column allowlist for dynamic sorting to validate the `order_by` input before query construction. Throws a `ValueError` if the requested column is not in the allowlist.
✅ Verification: Created local temporary tests to verify the injection vector was closed. Ran `uv run pytest tests/test_conversation_store.py` to ensure legitimate functionality was unaffected.

---
*PR created automatically by Jules for task [16822152510896691668](https://jules.google.com/task/16822152510896691668) started by @EffortlessSteven*