### PR TITLE
🎨 Palette: Add critical warning for sample copy overwrite

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## $(date -I) - Destructive Action Confirmation
+**Learning:** Destructive actions require distinct visual warnings in interactive prompts to enforce attention, as plain text is often missed.
+**Action:** Always use `Colors.red()` for critical warnings like "This cannot be undone." when prompting the user for confirmation on actions that delete or overwrite data.

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -872,7 +872,8 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                warning = Colors.red("This cannot be undone.")
+                confirm = input(f"Overwrite? {warning} [y/N] ")
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
**💡 What:** Added a critical visual warning ("This cannot be undone.") in `Colors.red()` to the interactive prompt that appears before overwriting existing files in the `samples copy` command.
**🎯 Why:** Destructive actions (overwriting local data) should always require conscious attention. A plain text prompt might be quickly skipped over.
**📸 Before/After:** N/A (CLI change)
**♿ Accessibility:** Enhances cognitive accessibility by clearly distinguishing destructive action prompts from standard informational prompts using established terminal color semantics (red for danger).

---
*PR created automatically by Jules for task [3807198940722058438](https://jules.google.com/task/3807198940722058438) started by @EffortlessSteven*