### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery order_by

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-06-15 - Fix SQL Injection in ORDER BY Clause
+**Vulnerability:** SQL Injection via string interpolation in the SQLite `ORDER BY` clause of `StoreQuery`.
+**Learning:** Parameterized queries (`?`) cannot be used for column names or `ORDER BY` fields. Directly interpolating user-controlled input like `query.order_by` allows attackers to inject arbitrary subqueries (e.g., Boolean-based blind SQLi).
+**Prevention:** Always validate column names against a strict allowlist of known, safe columns before interpolating them into a SQL query.

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -919,7 +919,13 @@ class SQLiteConversationStore:
                 params.append(query.date_range.before)
 
         # Order by
-        order_col = "rank" if query.text else query.order_by
+        if query.text:
+            order_col = "rank"
+        else:
+            # Sanitize order_by to prevent SQL injection
+            valid_order_cols = {"start_time", "end_time", "segment_index", "speaker_confidence"}
+            order_col = query.order_by if query.order_by in valid_order_cols else "start_time"
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The SQLite `ORDER BY` clause string interpolation using `StoreQuery.order_by` allowed for boolean-based blind SQL injection via embedded subqueries.
🎯 **Impact:** An attacker controlling the `order_by` parameter could extract arbitrary data from other database tables via side channels.
🔧 **Fix:** Introduced an explicit allowlist validation `{"start_time", "end_time", "segment_index", "speaker_confidence"}` in `transcription/store/store.py`. Unlisted fields fallback securely to `start_time`.
✅ **Verification:** A regression test utilizing `order_by="CASE WHEN (SELECT count(name) FROM sqlite_master) > 0 THEN start_time ELSE end_time END"` verified that the payload gracefully defaults rather than executing the subquery. Existing `test_conversation_store.py` tests continue to pass.

---
*PR created automatically by Jules for task [10251869999266890752](https://jules.google.com/task/10251869999266890752) started by @EffortlessSteven*