### PR TITLE
🎨 Palette: Add destructive action confirmation to speaker deletion

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1557,13 +1557,16 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
         print(f"Speaker not found: {args.speaker_id}", file=sys.stderr)
         return 1
 
+    from transcription.color_utils import Colors
+
     # Confirm deletion
     if not args.force:
         if not sys.stdin.isatty():
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 **What**: Added a critical visual warning (`"This cannot be undone."` in red) to the interactive speaker deletion prompt in the CLI.
🎯 **Why**: Destructive actions should have a distinct visual warning. Plain text warnings without color formatting are easily missed by users, increasing the risk of accidental data loss. This change enforces consistency with other destructive commands (like `cache clear`) across the CLI.
📸 **Before/After**: 
Before: `Delete speaker 'Alice' (SPEAKER_00)? [y/N]`
After: `Delete speaker 'Alice' (SPEAKER_00)? This cannot be undone. [y/N]` (with "This cannot be undone." colored red)
♿ **Accessibility**: Improves cognitive accessibility by providing an explicit, distinct warning for a high-risk operation, preventing user errors.

---
*PR created automatically by Jules for task [17138531843465329522](https://jules.google.com/task/17138531843465329522) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only prompt formatting with no changes to deletion behavior or data paths.
> 
> **Overview**
> The interactive **`speakers delete`** confirmation now shows a red **"This cannot be undone."** message in the prompt, using the same `Colors.red` pattern as **`cache clear`**.
> 
> Deletion logic, `--force`, and non-interactive behavior are unchanged; only the TTY confirmation string is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1051f18dd3c69242a78212553d7a578e9b093c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->