### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-01-28 - StoreQuery SQL Injection
+**Vulnerability:** SQL Injection in SQLiteConversationStore search logic via unvalidated `order_by` parameter.
+**Learning:** Even internal query objects (`StoreQuery.order_by`) can lead to SQL injection if their values are directly formatted into SQL strings (`f"ORDER BY {order_col} {order_dir}"`).
+**Prevention:** Always validate columns against an explicit allowlist before using them in dynamic SQL constructs like `ORDER BY`, which cannot be parameterized.

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -919,7 +919,11 @@ class SQLiteConversationStore:
                 params.append(query.date_range.before)
 
         # Order by
+        # Sentinel: SQL Injection fix via explicit allowlist
+        allowed_columns = {"start_time", "end_time", "rank", "speaker_id", "transcript_id", "segment_index"}
         order_col = "rank" if query.text else query.order_by
+        if order_col not in allowed_columns:
+            order_col = "start_time"
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 Severity: CRITICAL\n💡 Vulnerability: SQL Injection in SQLiteConversationStore search logic via unvalidated `order_by` parameter.\n🎯 Impact: An attacker could execute arbitrary SQL commands leading to data exfiltration or corruption.\n🔧 Fix: Implemented an explicit allowlist for `order_by` columns.\n✅ Verification: Ran relevant test suite (`tests/test_conversation_store.py`) to confirm fix.

---
*PR created automatically by Jules for task [18178168109760235708](https://jules.google.com/task/18178168109760235708) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, defensive change in store search ordering with no auth or schema changes; residual risk is only if the allowlist omits a legitimate column clients relied on.
> 
> **Overview**
> **Fixes SQL injection** in `SQLiteConversationStore.search()` where `StoreQuery.order_by` was interpolated into the dynamic `ORDER BY` clause without validation.
> 
> The search path now **allowlists** sort columns (`start_time`, `end_time`, `rank`, `speaker_id`, `transcript_id`, `segment_index`). Invalid values fall back to `start_time`; text searches still prefer `rank` when applicable. **Sentinel notes** in `.jules/sentinel.md` document the issue and the allowlist pattern for non-parameterizable `ORDER BY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66feb720bd35bceb523cca0380f5d878490255a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->