### PR TITLE
🎨 Palette: [UX improvement] Add clear warning to speaker deletion prompt

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -52,6 +52,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from transcription.color_utils import Colors
+
 if TYPE_CHECKING:
     from transcription.models import Transcript
 
@@ -1563,7 +1565,8 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Added `Colors.red()` warning to the speaker deletion prompt.
🎯 Why: Destructive actions like deleting a speaker require distinct visual warnings to prevent accidental data loss.
📸 Before/After: Before it was plain text. After it has a red warning text.
♿ Accessibility: Using a distinct red color for destructive warnings helps enforce attention and improve usability.

---
*PR created automatically by Jules for task [16929297661932637258](https://jules.google.com/task/16929297661932637258) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only copy and terminal styling on an existing confirmation path; no registry or deletion logic changes.
> 
> **Overview**
> The interactive **`speakers delete`** confirmation now includes a **red** “This cannot be undone.” message via `Colors.red()`, wired through a new `Colors` import in `speaker_identity.py`.
> 
> Deletion behavior is unchanged: non-interactive runs still require `--force`, and the same `[y/N]` prompt applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f36bc29b153e04f40c142b0301fdea779b23a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->