### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in search order_by

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
 **Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
 **Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+
+## 2026-01-29 - SQL Injection in ORDER BY clause
+**Vulnerability:** SQL injection via string concatenation in the `ORDER BY` clause of the search method (`sql_parts.append(f"ORDER BY {order_col} {order_dir}")`).
+**Learning:** Even if `WHERE` clauses correctly use parameterized queries (`?`), `ORDER BY` and `GROUP BY` column names cannot be parameterized in SQLite. Allowing user input here directly leads to SQL injection.
+**Prevention:** Always validate column names against a strict allowlist of allowed columns before concatenating them into the query.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1048,3 +1048,10 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+    def test_search_order_by_sql_injection(self) -> None:
+        """Test that order_by parameter is safe from SQL injection."""
+        with ConversationStore(":memory:") as store:
+            query = StoreQuery(order_by="start_time; DROP TABLE transcripts; --")
+            with pytest.raises(ValueError, match="Invalid order_by column"):
+                store.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -919,7 +919,12 @@ class SQLiteConversationStore:
                 params.append(query.date_range.before)
 
         # Order by
+        # Sentinel: SQL Injection fix via explicit allowlist
+        allowed_order_cols = {"start_time", "end_time", "speaker_id", "segment_index", "transcript_id", "rank"}
         order_col = "rank" if query.text else query.order_by
+        if order_col not in allowed_order_cols:
+            raise ValueError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsanitized string concatenation in the `ORDER BY` clause allowed for direct SQL Injection vectors when using the `ConversationStore.search()` function with the `StoreQuery(order_by=...)` field.
🎯 **Impact:** An attacker could craft a malicious `order_by` string that allows arbitrary SQL statements to be executed, potentially reading sensitive data or dropping tables.
🔧 **Fix:** Replaced direct string formatting with a strict allowlist check (`allowed_order_cols`). If the requested `order_by` field is not in the set of known, safe columns (`start_time`, `end_time`, `speaker_id`, `segment_index`, `transcript_id`, `rank`), it safely raises a `ValueError`.
✅ **Verification:** A test case `test_search_order_by_sql_injection` was added to `tests/test_conversation_store.py` that confirms `ValueError` is raised instead of executing the injected SQL snippet. All tests pass locally.

---
*PR created automatically by Jules for task [4196786335629451035](https://jules.google.com/task/4196786335629451035) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes a critical SQL injection vector in search; behavior change rejects previously accepted invalid order_by values with ValueError instead of executing SQL.
> 
> **Overview**
> Closes an **SQL injection** path in `ConversationStore.search()` where `StoreQuery.order_by` was interpolated into the `ORDER BY` clause without validation.
> 
> Before building the query, the sort column is checked against a fixed allowlist (`start_time`, `end_time`, `speaker_id`, `segment_index`, `transcript_id`, `rank`). Values outside that set raise **`ValueError`** instead of being appended to SQL. Text searches still force ordering by `rank` as before.
> 
> A regression test asserts that a malicious `order_by` string (e.g. with `DROP TABLE`) is rejected. **`.jules/sentinel.md`** records the pattern and prevention guidance for future reviews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ad7db7e24b860fb524f7bb5a9f67c7db3108211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->