### PR TITLE
🎨 Palette: Handle KeyboardInterrupt gracefully in CLI prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2025-02-28 - Graceful Exit on Interrupts
+**Learning:** Interactive command-line prompts should gracefully handle KeyboardInterrupts (Ctrl+C). A raw stack trace is a bad UX when the user is simply trying to cancel an action.
+**Action:** Always wrap `input()` calls in a `try...except KeyboardInterrupt:` block and print a clean "\nAborted." message to exit gracefully.

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,9 +799,13 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
-            if confirm.lower() not in ("y", "yes"):
-                print("Aborted.")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+                if confirm.lower() not in ("y", "yes"):
+                    print("Aborted.")
+                    return 0
+            except KeyboardInterrupt:
+                print("\nAborted.")
                 return 0
 
         for name, target in targets:
@@ -872,9 +876,13 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
-                if confirm.lower() not in ("y", "yes"):
-                    print("Aborted.")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                    if confirm.lower() not in ("y", "yes"):
+                        print("Aborted.")
+                        return 0
+                except KeyboardInterrupt:
+                    print("\nAborted.")
                     return 0
 
                 # Retry with overwrite=True

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,9 +1563,13 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
-        if confirm.lower() not in ("y", "yes"):
-            print("Aborted.")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+            if confirm.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return 0
+        except KeyboardInterrupt:
+            print("\nAborted.")
             return 0
 
     # Delete speaker


### PR DESCRIPTION
💡 **What**: Wrapped interactive `input()` prompts in `try...except KeyboardInterrupt` blocks.
🎯 **Why**: When a user presses `Ctrl+C` to cancel out of a confirmation prompt, Python historically dumped a raw stack trace. This provides a poor UX for simple action cancellation.
📸 **Before/After**: Before: users see a messy Python `KeyboardInterrupt` traceback. After: users see a clean `\nAborted.` exit message.
♿ **Accessibility**: N/A - but improves general CLI usability for terminal power users relying on standard interrupt keystrokes.

---
*PR created automatically by Jules for task [13182576443896650368](https://jules.google.com/task/13182576443896650368) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only change to interactive prompts; no change to default behavior when users confirm or use --force.
> 
> **Overview**
> Interactive **confirmation prompts** now treat **Ctrl+C** like a cancel: users see a clean `\nAborted.` message and exit with code **0** instead of a Python traceback.
> 
> This applies to **`cache --clear`**, **`samples copy`** overwrite confirmation, and **`speakers delete`**. Declining with **N** still prints `Aborted.` and returns **0**; the control flow is unchanged aside from the interrupt handling.
> 
> **`.jules/palette.md`** records the rule to wrap `input()` in `try...except KeyboardInterrupt` for future CLI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67110e88ae23e07e1596cfc0de033b8a50c4648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->