### PR TITLE
🎨 Palette: Add visual warning to destructive speaker deletion prompt

### DIFF
--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -54,6 +54,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from transcription.models import Transcript
+from .color_utils import Colors
 
 logger = logging.getLogger(__name__)
 
@@ -1563,7 +1564,12 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        warning = Colors.red("This cannot be undone.")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? {warning} [y/N] ")
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 0
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
**💡 What**
Added a clear, red visual warning (`This cannot be undone.`) to the speaker deletion confirmation prompt. Also added a `KeyboardInterrupt` catch to ensure that hitting `Ctrl+C` cleanly aborts the action without printing a raw python stack trace.

**🎯 Why**
Destructive actions in CLI tools need distinct visual cues so users don't skip over plain-text confirmation prompts out of habit. The added `try-except` handles user cancellation gracefully.

**📸 Before/After**
*Before:* `Delete speaker 'Alice' (SPEAKER_00)? [y/N]`
*After:* `Delete speaker 'Alice' (SPEAKER_00)? [31mThis cannot be undone.[0m [y/N]` (rendered in red in terminal)

**♿ Accessibility**
Reduces cognitive load and prevents accidental destructive actions by providing a contrasting visual warning. Clean exit behavior on `Ctrl+C` prevents exposing confusing/intimidating stack traces to end users.

---
*PR created automatically by Jules for task [7299080376703084632](https://jules.google.com/task/7299080376703084632) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX around the delete confirmation path; no registry or embedding logic changes.
> 
> **Overview**
> The interactive **`speakers delete`** confirmation now includes a red **“This cannot be undone.”** warning via `Colors.red`, reusing the existing terminal color helpers.
> 
> **Ctrl+C** during the prompt is caught as `KeyboardInterrupt`, prints **Aborted.**, and exits with code 0 instead of showing a Python traceback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1204e360c8b60331008a7b84cfd5282f8426b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->