### PR TITLE
🎨 Palette: [UX improvement] Graceful Ctrl+C handling in interactive CLI prompts

### DIFF
--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,11 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            except KeyboardInterrupt:
+                print("\nAborted.")
+                return 0
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +876,11 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                except KeyboardInterrupt:
+                    print("\nAborted.")
+                    return 0
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,7 +1563,11 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        except KeyboardInterrupt:
+            print("\nAborted.")
+            return 0
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 **What:** 
Added `try...except KeyboardInterrupt:` blocks around interactive `input()` prompts in `transcription/cli.py` (cache clearing and sample copying) and `transcription/speaker_identity.py` (speaker deletion).

🎯 **Why:** 
When users press `Ctrl+C` to cancel out of an interactive prompt, Python throws a `KeyboardInterrupt` which results in an ugly and intimidating stack trace being dumped to the terminal. Catching this exception allows the CLI to exit cleanly with a simple "Aborted." message, making the tool feel much more polished and user-friendly.

📸 **Before/After:** 
*Before:*
```
Clear all cache (12.4 MB)? This cannot be undone. [y/N] ^C
Traceback (most recent call last):
  File ".../transcription/cli.py", line 802, in _handle_cache_command
    confirm = input(...)
KeyboardInterrupt
```
*After:*
```
Clear all cache (12.4 MB)? This cannot be undone. [y/N] ^C
Aborted.
```

♿ **Accessibility:** 
Improves keyboard interaction. Users relying on keyboard shortcuts (like `Ctrl+C` for interrupt) receive a structured, expected response rather than an application crash dump, reducing cognitive load and confusion.

---
*PR created automatically by Jules for task [2494725936700170731](https://jules.google.com/task/2494725936700170731) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX-only change around confirmation prompts; no change to destructive actions when the user confirms or uses `--force`.
> 
> **Overview**
> Interactive **y/N** confirmations now treat **Ctrl+C** like a cancel instead of surfacing a **KeyboardInterrupt** traceback.
> 
> The same `try`/`except` pattern is applied around `input()` in **cache clear**, **samples copy** overwrite, and **speakers delete** flows: print `Aborted.` and exit with code **0**, matching the existing “no” / declined path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e654cd8a90c009c18ce66ade510c7639cb9b135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->