### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in StoreQuery

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,9 @@
-## 2026-01-28 - FastAPI Security Headers & CSP
-**Vulnerability:** Missing security headers (X-Content-Type-Options, X-Frame-Options, CSP) in FastAPI service.
-**Learning:** Default strict CSP (`default-src 'self'`) breaks FastAPI's auto-generated docs (Swagger UI/Redoc) which rely on `cdn.jsdelivr.net` and `unsafe-inline` styles/scripts.
-**Prevention:** Use a middleware to add security headers, but ensure CSP explicitly allows `cdn.jsdelivr.net` and `fastapi.tiangolo.com` if API docs are enabled.
+## 2024-06-21 - SQL Injection in StoreQuery ORDER BY
+**Vulnerability:** The `ConversationStore.search()` method interpolates the `query.order_by` field directly into a SQL query string (`ORDER BY {order_col} {order_dir}`) without sanitizing it or ensuring it refers to an allowed column name.
+**Learning:** `order_by` fields supplied by the query model are vulnerable to SQL injection because standard parameterized queries (using `?`) can only be used for literal values, not column names or identifiers.
+**Prevention:** Use an explicit allowlist of valid column names to map the `order_by` field before interpolating it into the SQL query string.
+
+## 2024-06-21 - SQL Injection in StoreQuery ORDER BY
+**Vulnerability:** The `ConversationStore.search()` method interpolates the `query.order_by` field directly into a SQL query string (`ORDER BY {order_col} {order_dir}`) without sanitizing it or ensuring it refers to an allowed column name.
+**Learning:** `order_by` fields supplied by the query model are vulnerable to SQL injection because standard parameterized queries (using `?`) can only be used for literal values, not column names or identifiers.
+**Prevention:** Use an explicit allowlist of valid column names to map the `order_by` field before interpolating it into the SQL query string.

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -27,6 +27,7 @@ from transcription.store import (
     ExportFormat,
     ExportOptions,
     IngestOptions,
+    QueryError,
     QueryFilter,
     SpeakerQuery,
     StoreError,
@@ -1048,3 +1049,9 @@ class TestParquetExport:
         assert len(table) == 4
         assert "text" in table.column_names
         assert "transcript_id" in table.column_names
+
+    def test_search_sql_injection_order_by(self, store_with_data: ConversationStore) -> None:
+        """Test that SQL injection in order_by raises QueryError."""
+        query = StoreQuery(order_by="start_time; DROP TABLE segments")
+        with pytest.raises(QueryError, match="Invalid order_by column"):
+            store_with_data.search(query)

--- a/transcription/store/store.py
+++ b/transcription/store/store.py
@@ -919,7 +919,19 @@ class SQLiteConversationStore:
                 params.append(query.date_range.before)
 
         # Order by
+        # Sentinel: SQL Injection fix via explicit allowlist for ORDER BY clause
+        allowed_order_cols = {
+            "start_time",
+            "end_time",
+            "segment_index",
+            "speaker_id",
+            "speaker_confidence",
+            "rank",
+        }
         order_col = "rank" if query.text else query.order_by
+        if order_col not in allowed_order_cols:
+            raise QueryError(f"Invalid order_by column: {order_col}")
+
         order_dir = "DESC" if query.order_desc else "ASC"
         sql_parts.append(f"ORDER BY {order_col} {order_dir}")
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `ConversationStore.search()` method interpolates the `query.order_by` field directly into a SQL query string without sanitizing it or ensuring it refers to an allowed column name, leading to a SQL injection vulnerability.
🎯 **Impact:** An attacker could craft a malicious `order_by` string to execute arbitrary SQL commands, potentially exposing sensitive data, modifying the database, or dropping tables.
🔧 **Fix:** Added an explicit allowlist of valid column names in `transcription/store/store.py` to map the `order_by` field before interpolating it into the SQL query string. If an invalid column name is provided, a `QueryError` is raised.
✅ **Verification:** Added a unit test `test_search_sql_injection_order_by` in `tests/test_conversation_store.py` that verifies attempting SQL injection via `order_by` raises a `QueryError`. Verified the fix locally by running the test suite with `uv run pytest tests/test_conversation_store.py`.

---
*PR created automatically by Jules for task [9562350050971102714](https://jules.google.com/task/9562350050971102714) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Closes a critical SQL injection path in store search; behavior change only rejects previously dangerous `order_by` values.
> 
> **Overview**
> **`ConversationStore.search()`** no longer trusts `StoreQuery.order_by` when building the `ORDER BY` clause. It resolves the sort column (`rank` for text search, otherwise `order_by`), checks it against a fixed allowlist (`start_time`, `end_time`, `segment_index`, `speaker_id`, `speaker_confidence`, `rank`), and raises **`QueryError`** with *Invalid order_by column* if it is not allowed—blocking identifier injection that bound parameters cannot prevent.
> 
> A regression test asserts that a malicious `order_by` like `start_time; DROP TABLE segments` fails with that error. **`.jules/sentinel.md`** documents the finding and fix (the prior FastAPI CSP note was removed from that file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b7a940c95752ca5c31bcb48573768ef68ea318d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->