### PR TITLE
🎨 Palette: Handle KeyboardInterrupt gracefully in CLI prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-01-27 - Graceful Abort
+**Learning:** Raw stack traces from `KeyboardInterrupt` during `input()` prompts look like crashes and cause alarm.
+**Action:** Always wrap `input()` calls in `try...except KeyboardInterrupt:` to fail gracefully with an "Aborted." message.

--- a/tests/test_cli_cache.py
+++ b/tests/test_cli_cache.py
@@ -58,6 +58,21 @@ class TestCacheClearConfirmation:
             captured = capsys.readouterr()
             assert "Aborted" in captured.out
 
+    def test_interactive_prompt_keyboard_interrupt(self, mock_cache_paths, capsys):
+        """KeyboardInterrupt during prompt aborts cleanly."""
+        with (
+            patch("shutil.rmtree") as mock_rmtree,
+            patch("builtins.input", side_effect=KeyboardInterrupt) as mock_input,
+            patch("sys.stdin.isatty", return_value=True),
+        ):
+            exit_code = main(["cache", "--clear", "whisper"])
+
+            assert exit_code == 0
+            assert mock_input.called
+            assert not mock_rmtree.called
+            captured = capsys.readouterr()
+            assert "Aborted" in captured.out
+
     @pytest.mark.parametrize("force_flag", ["--force", "-f", "-y"])
     def test_force_flags_skip_prompt(self, mock_cache_paths, force_flag):
         """--force and its aliases skip the confirmation prompt entirely."""

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,11 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            except KeyboardInterrupt:
+                print("\nAborted.")
+                return 0
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +876,11 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                except KeyboardInterrupt:
+                    print("\nAborted.")
+                    return 0
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
💡 What:
Wrapped `input()` calls in the CLI (for cache clear and sample overwrite confirmations) with `try...except KeyboardInterrupt` blocks that print a clean "Aborted." message and exit with code 0. Also updated the Palette journal and added a pytest coverage case.

🎯 Why:
Pressing Ctrl+C during a CLI prompt previously resulted in a raw `KeyboardInterrupt` stack trace being printed to the terminal, which looks like an application crash and causes user alarm. Failing gracefully is a standard and expected CLI behavior.

📸 Before/After:
Before:
```
Clear all cache (10MB)? This cannot be undone. [y/N] ^C
Traceback (most recent call last):
  File "transcription/cli.py", line 802, in main
    confirm = input(...)
KeyboardInterrupt
```
After:
```
Clear all cache (10MB)? This cannot be undone. [y/N] ^C
Aborted.
```

♿ Accessibility:
N/A (terminal interaction improvement rather than strict a11y, but reduces cognitive load/confusion for all users).

---
*PR created automatically by Jules for task [18063548094819003423](https://jules.google.com/task/18063548094819003423) started by @EffortlessSteven*