### PR TITLE
🎨 Palette: Graceful KeyboardInterrupt handling

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-02-09 - CLI Graceful Exits
+**Learning:** Exposing raw Python stack traces on `Ctrl+C` during interactive `input()` prompts in CLI applications creates a jarring, unpolished experience.
+**Action:** Always wrap interactive CLI prompts (`input()`) in a `try...except KeyboardInterrupt:` block to exit cleanly with `\nAborted.`.

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,12 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            except KeyboardInterrupt:
+                print("\nAborted.")
+                return 0
+
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +877,12 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                except KeyboardInterrupt:
+                    print("\nAborted.")
+                    return 0
+
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
💡 **What:** Added graceful `KeyboardInterrupt` handling to CLI confirmation prompts (clearing cache and overwriting samples).
🎯 **Why:** Exposing a raw Python stack trace when a user presses `Ctrl+C` is an unpolished, jarring user experience. Exiting cleanly with `\nAborted.` is much more pleasant and expected in standard CLI tools.
📸 **Before/After:** N/A (Console behavior change from traceback to clean exit)
♿ **Accessibility:** N/A

---
*PR created automatically by Jules for task [6933568217816734569](https://jules.google.com/task/6933568217816734569) started by @EffortlessSteven*