### PR TITLE
🎨 Palette: Graceful exit on CLI prompt cancellation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-01-27 - Graceful Exit on Interrupts
+**Learning:** Raw stack traces from `KeyboardInterrupt` or `EOFError` during interactive CLI prompts ruin the UX, making the tool feel fragile.
+**Action:** When implementing interactive prompts using `input()`, wrap the call in a `try...except (KeyboardInterrupt, EOFError):` block and exit cleanly (e.g., printing `\nAborted.`).

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,9 +799,13 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
-            if confirm.lower() not in ("y", "yes"):
-                print("Aborted.")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+                if confirm.lower() not in ("y", "yes"):
+                    print("Aborted.")
+                    return 0
+            except (KeyboardInterrupt, EOFError):
+                print("\nAborted.")
                 return 0
 
         for name, target in targets:
@@ -872,9 +876,13 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
-                if confirm.lower() not in ("y", "yes"):
-                    print("Aborted.")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                    if confirm.lower() not in ("y", "yes"):
+                        print("Aborted.")
+                        return 0
+                except (KeyboardInterrupt, EOFError):
+                    print("\nAborted.")
                     return 0
 
                 # Retry with overwrite=True

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,9 +1563,13 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
-        if confirm.lower() not in ("y", "yes"):
-            print("Aborted.")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+            if confirm.lower() not in ("y", "yes"):
+                print("Aborted.")
+                return 0
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
             return 0
 
     # Delete speaker


### PR DESCRIPTION
💡 What: Wrapped interactive `input()` calls in `try...except (KeyboardInterrupt, EOFError)` blocks in `transcription/cli.py` and `transcription/speaker_identity.py`.
🎯 Why: To provide a clean `\nAborted.` exit instead of exposing raw stack traces when users cancel prompts with Ctrl+C or Ctrl+D.
📸 Before/After: Before it threw `EOFError` or `KeyboardInterrupt` with a Python traceback. Now it exits cleanly with `Aborted.`.
♿ Accessibility: Improves CLI usability and predictability by preventing error dumps on user intent to exit.

---
*PR created automatically by Jules for task [14695527769589870073](https://jules.google.com/task/14695527769589870073) started by @EffortlessSteven*