### PR TITLE
🎨 Palette: Gracefully handle keyboard interrupts in CLI prompts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-01-26 - Graceful CLI Interrupts
+**Learning:** Raw stack traces from user cancellations (Ctrl+C, Ctrl+D) during CLI prompts create a poor, confusing experience that looks like a crash.
+**Action:** Always wrap interactive CLI `input()` prompts in a `try...except (KeyboardInterrupt, EOFError):` block to catch interrupts and exit cleanly with a clear message (e.g., `\nAborted.`).

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,11 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            except (KeyboardInterrupt, EOFError):
+                print("\nAborted.")
+                return 0
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +876,11 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                except (KeyboardInterrupt, EOFError):
+                    print("\nAborted.")
+                    return 0
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0


### PR DESCRIPTION
💡 What: Wrapped `input()` prompts in `transcription/cli.py` in `try...except (KeyboardInterrupt, EOFError)` blocks.
🎯 Why: To prevent exposing raw stack traces when users cancel prompts using `Ctrl+C` or `Ctrl+D`, improving the terminal UX.
📸 Before/After: Before, `Ctrl+C` threw a stack trace. After, it prints `\nAborted.` and exits gracefully.
♿ Accessibility: Improves CLI usability by providing clear and controlled exit messages when users bail out of interactive prompts.

---
*PR created automatically by Jules for task [4613659332202478313](https://jules.google.com/task/4613659332202478313) started by @EffortlessSteven*