### PR TITLE
⚡ Bolt: Optimize RMS energy calculation to avoid temporary array allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-06-26 - Optimized RMS Energy Calculation
+**Learning:** `np.mean(audio**2)` in NumPy creates a temporary array for the squared values, which can cause significant memory pressure and slowdowns in hot paths like streaming audio processing.
+**Action:** Always use `np.vdot(audio, audio) / audio.size` instead for calculating RMS energy, as it avoids the temporary array allocation and handles multidimensional arrays safely.

--- a/transcription/audio_health.py
+++ b/transcription/audio_health.py
@@ -111,7 +111,7 @@ def analyze_chunk_health(
     clipping_ratio = float(clipped_count / n_samples)
 
     # 2. Compute RMS energy
-    rms_energy = float(np.sqrt(np.mean(samples_float**2)))
+    rms_energy = float(np.sqrt(np.vdot(samples_float, samples_float) / samples_float.size))
 
     # 3. Compute SNR proxy (ratio of top 10% energy to bottom 10%)
     snr_proxy = _compute_snr_proxy(samples_float)

--- a/transcription/prosody.py
+++ b/transcription/prosody.py
@@ -228,7 +228,7 @@ def extract_energy_features(audio: np.ndarray, sr: int) -> dict[str, Any]:
         logger.warning("Librosa not available, using numpy for energy extraction")
         # Fallback to simple RMS calculation
         try:
-            rms = np.sqrt(np.mean(audio**2))
+            rms = np.sqrt(np.vdot(audio, audio) / audio.size)
             db_rms = 20 * np.log10(rms + 1e-10) if rms > 0 else -100
             return {"rms_mean": float(rms), "rms_std": 0.0, "db_rms": float(db_rms)}
         except Exception:
@@ -330,7 +330,7 @@ def detect_pauses(
                 start = i * hop_length
                 end = start + frame_length
                 frame = audio[start:end]
-                rms[i] = np.sqrt(np.mean(frame**2))
+                rms[i] = np.sqrt(np.vdot(frame, frame) / frame.size)
 
         # Convert to dB
         db = 20 * np.log10(rms + 1e-10)

--- a/transcription/prosody_extended.py
+++ b/transcription/prosody_extended.py
@@ -374,9 +374,13 @@ def _linear_regression(x: np.ndarray, y: np.ndarray) -> tuple[float, float, floa
     x_mean = np.mean(x)
     y_mean = np.mean(y)
 
+    # Pre-center arrays for optimized vdot operations
+    x_centered = x - x_mean
+    y_centered = y - y_mean
+
     # Compute slope
-    numerator = np.sum((x - x_mean) * (y - y_mean))
-    denominator = np.sum((x - x_mean) ** 2)
+    numerator = np.vdot(x_centered, y_centered)
+    denominator = np.vdot(x_centered, x_centered)
 
     if denominator == 0:
         return 0.0, y_mean, 0.0

--- a/transcription/streaming_asr.py
+++ b/transcription/streaming_asr.py
@@ -184,7 +184,7 @@ class StreamingASRAdapter:
         """
         if len(audio) == 0:
             return 0.0
-        return float(np.sqrt(np.mean(audio**2)))
+        return float(np.sqrt(np.vdot(audio, audio) / audio.size))
 
     def _detect_speech_frames(self, audio: np.ndarray, frame_size_ms: int = 30) -> list[bool]:
         """Detect speech in audio using frame-wise energy analysis.


### PR DESCRIPTION
## 💡 What
Replaced all instances of `np.mean(audio**2)` (and similar variations for energy calculation) with `np.vdot(audio, audio) / audio.size`. Also updated linear regression calculations in `transcription/prosody_extended.py` to use `np.vdot` on pre-centered arrays instead of `np.sum()`.

## 🎯 Why
Calculating `audio**2` in NumPy allocates a temporary array in memory equal to the size of the input audio buffer before computing the mean. In streaming or high-throughput audio contexts, these constant allocations cause memory pressure and slow down processing. `np.vdot` computes the dot product directly using highly optimized internal routines without creating an intermediate array, yielding a faster and more memory-efficient calculation.

## 📊 Impact
* Eliminates O(N) temporary memory allocations in core RMS energy calculations.
* Provides a noticeable micro-optimization in tight streaming loops (`_detect_speech_frames` in `streaming_asr.py`) and batch audio health checks.
* Safely processes multi-dimensional arrays (if any sneak through) since `np.vdot` inherently flattens arrays, matching the behavior of `np.mean`.

## 🔬 Measurement
1. Review the memory usage profile of long-running streaming transcriptions; temporary allocations from `np.mean(audio**2)` will be gone.
2. Run `uv run pytest tests/test_prosody.py tests/test_prosody_extended.py tests/test_audio_health.py tests/test_streaming_asr.py` to ensure numerical equivalence and mathematical correctness are maintained.

---
*PR created automatically by Jules for task [5115742063707593560](https://jules.google.com/task/5115742063707593560) started by @EffortlessSteven*