### PR TITLE
🎨 Palette: Add HTML landmarks and graceful CLI aborts

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,11 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-02-12 - Handling User Interrupts
+**Learning:** Raw stack traces from `KeyboardInterrupt` or `EOFError` in interactive CLIs are poor UX and can panic users.
+**Action:** Always wrap `input()` calls in `try...except (KeyboardInterrupt, EOFError)` and exit cleanly (e.g., `print("\nAborted.")`) for interactive CLI prompts.
+
+## 2026-02-12 - Screen Reader Landmarks
+**Learning:** Missing `<main>` landmarks and `lang` attributes make raw HTML logs (like transcript exports) harder to navigate for screen readers.
+**Action:** Add `<html lang="...">` and wrap the core content in `<main>` when generating HTML files, even simple ones.

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,12 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            except (KeyboardInterrupt, EOFError):
+                print("\nAborted.")
+                return 0
+
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +877,12 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                except (KeyboardInterrupt, EOFError):
+                    print("\nAborted.")
+                    return 0
+
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/exporters.py
+++ b/transcription/exporters.py
@@ -111,9 +111,10 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
     """Write a simple annotated HTML transcript."""
     rows = _collect_segments(transcript, unit=unit)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    lang_attr = f' lang="{html.escape(transcript.language)}"' if transcript.language else ""
     parts: list[str] = [
         "<!doctype html>",
-        "<html>",
+        f"<html{lang_attr}>",
         "<head>",
         '<meta charset="utf-8" />',
         "<title>Transcript</title>",
@@ -125,6 +126,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
         "</style>",
         "</head>",
         "<body>",
+        "<main>",
         f"<h2>{html.escape(transcript.file_name)}</h2>",
     ]
     for row in rows:
@@ -138,7 +140,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
             f"<div>{html.escape(row['text'])}</div>"
             "</div>"
         )
-    parts.extend(["</body>", "</html>"])
+    parts.extend(["</main>", "</body>", "</html>"])
     output_path.write_text("\n".join(parts), encoding="utf-8")
 
 

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,7 +1563,12 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
+            return 0
+
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 **What:** 
- Added semantic `<main>` landmarks and `<html lang="...">` attributes to HTML transcript exports.
- Wrapped interactive CLI prompts (for cache clearing, sample copying, and speaker deletion) in `try...except (KeyboardInterrupt, EOFError)` blocks to catch user aborts.

🎯 **Why:** 
- Raw HTML logs without landmarks or lang attributes are difficult for screen readers to parse and navigate.
- Raw stack traces when a user hits Ctrl+C in the CLI are terrible UX and make the application look broken.

📸 **Before/After:**
- **Before CLI:** `Traceback (most recent call last)... KeyboardInterrupt`
- **After CLI:** `\nAborted.`
- **Before HTML:** `<html><body><h2>...`
- **After HTML:** `<html lang="en"><body><main><h2>...`

♿ **Accessibility:**
- The new `lang` attribute allows screen readers to select the correct pronunciation profile.
- The new `<main>` landmark allows screen reader users to skip directly to the primary transcript content.

---
*PR created automatically by Jules for task [12799246110245046](https://jules.google.com/task/12799246110245046) started by @EffortlessSteven*