### PR TITLE
🎨 Palette: [UX improvement] Graceful handling of Ctrl+C/Ctrl+D

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-26 - Atomic Pre-flight Checks
 **Learning:** For bulk file operations (like copying samples), users prefer a "check-then-act" model where all conflicts are reported upfront, rather than failing on the first conflict.
 **Action:** Implement pre-flight checks that gather *all* conflicts and raise a custom error (like `SampleExistsError`) containing the full list, allowing the CLI to present a complete summary before asking for confirmation.
+
+## 2026-06-28 - Graceful exit for input prompts
+**Learning:** Users who cancel an interactive CLI prompt using Ctrl+C or Ctrl+D expect a clean exit, rather than a raw Python stack trace.
+**Action:** Always wrap `input()` calls in a `try...except (KeyboardInterrupt, EOFError):` block and handle gracefully by printing `\nAborted.` and returning appropriately.

--- a/transcription/cli.py
+++ b/transcription/cli.py
@@ -799,7 +799,12 @@ def _handle_cache_command(args: argparse.Namespace) -> int:
             total_size = sum(_get_cache_size(path) for _, path in targets)
             size_str = _format_size(total_size)
             warning = Colors.red("This cannot be undone.")
-            confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            try:
+                confirm = input(f"Clear {args.clear} cache ({size_str})? {warning} [y/N] ")
+            except (KeyboardInterrupt, EOFError):
+                print("\nAborted.")
+                return 0
+
             if confirm.lower() not in ("y", "yes"):
                 print("Aborted.")
                 return 0
@@ -872,7 +877,12 @@ def _handle_samples_command(args: argparse.Namespace) -> int:
                 for f in e.existing_files:
                     print(f"  {f}")
 
-                confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                try:
+                    confirm = input(f"{Colors.red('Overwrite?')} [y/N] ")
+                except (KeyboardInterrupt, EOFError):
+                    print("\nAborted.")
+                    return 0
+
                 if confirm.lower() not in ("y", "yes"):
                     print("Aborted.")
                     return 0

--- a/transcription/speaker_identity.py
+++ b/transcription/speaker_identity.py
@@ -1563,7 +1563,12 @@ def _handle_delete(registry: SpeakerRegistry, args: Any) -> int:
             print("Error: Delete requires --force in non-interactive mode.", file=sys.stderr)
             return 1
 
-        confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        try:
+            confirm = input(f"Delete speaker '{speaker.name}' ({speaker.id})? [y/N] ")
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
+            return 0
+
         if confirm.lower() not in ("y", "yes"):
             print("Aborted.")
             return 0


### PR DESCRIPTION
💡 What: Wrapped `input()` prompts in `try...except (KeyboardInterrupt, EOFError):` blocks to catch standard exit signals during interactive CLI flows.
🎯 Why: Prevents ugly Python stack traces when users cancel an action midway (e.g., clearing cache, overwriting files, deleting speakers), making the tool feel more robust and professional.
📸 Before/After: N/A
♿ Accessibility: N/A (Standard CLI practice for terminal-based apps).

---
*PR created automatically by Jules for task [9098409203853477836](https://jules.google.com/task/9098409203853477836) started by @EffortlessSteven*