### PR TITLE
🎨 Palette: Add lang attribute and main landmark to HTML exports

### DIFF
--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -53,6 +53,8 @@ def test_export_formats(tmp_path: Path) -> None:
     html_text = html_path.read_text(encoding="utf-8")
     assert "Hello there" in html_text and "General Kenobi" in html_text
     assert "turn" in html_text
+    assert '<html lang="en">' in html_text
+    assert "<main>" in html_text
 
     vtt_path = tmp_path / "out.vtt"
     export_vtt(transcript, vtt_path, unit="segments")

--- a/transcription/exporters.py
+++ b/transcription/exporters.py
@@ -111,9 +111,10 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
     """Write a simple annotated HTML transcript."""
     rows = _collect_segments(transcript, unit=unit)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    lang_attr = html.escape(transcript.language) if transcript.language else "en"
     parts: list[str] = [
         "<!doctype html>",
-        "<html>",
+        f'<html lang="{lang_attr}">',
         "<head>",
         '<meta charset="utf-8" />',
         "<title>Transcript</title>",
@@ -125,6 +126,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
         "</style>",
         "</head>",
         "<body>",
+        "<main>",
         f"<h2>{html.escape(transcript.file_name)}</h2>",
     ]
     for row in rows:
@@ -138,7 +140,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
             f"<div>{html.escape(row['text'])}</div>"
             "</div>"
         )
-    parts.extend(["</body>", "</html>"])
+    parts.extend(["</main>", "</body>", "</html>"])
     output_path.write_text("\n".join(parts), encoding="utf-8")
 
 


### PR DESCRIPTION
💡 What: Added `<html lang="...">` and a `<main>` landmark to generated HTML transcripts.
🎯 Why: To improve screen reader accessibility and adhere to semantic HTML best practices.
📸 Before/After: Before, transcripts lacked a `lang` attribute and `<main>` landmark. After, they are fully accessible and properly annotated for screen readers.
♿ Accessibility: Ensures that screen readers know the default language of the exported transcript and can correctly identify the primary content of the page using the `<main>` landmark.

---
*PR created automatically by Jules for task [16467401637892671032](https://jules.google.com/task/16467401637892671032) started by @EffortlessSteven*