### PR TITLE
🎨 Palette: Add accessibility elements to HTML exports

### DIFF
--- a/features/steps/api_steps.py
+++ b/features/steps/api_steps.py
@@ -56,7 +56,9 @@ def _build_stub_client(base_url: str = "http://localhost:8765"):
             )
         if method == "GET" and path == "/docs":
             return httpx.Response(
-                200, text="<html><body>Docs</body></html>", headers={"content-type": "text/html"}
+                200,
+                text='<html lang="en"><body><main>Docs</main></body></html>',
+                headers={"content-type": "text/html"},
             )
         if method == "GET" and path == "/openapi.json":
             return httpx.Response(

--- a/transcription/exporters.py
+++ b/transcription/exporters.py
@@ -113,7 +113,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
     output_path.parent.mkdir(parents=True, exist_ok=True)
     parts: list[str] = [
         "<!doctype html>",
-        "<html>",
+        '<html lang="en">',
         "<head>",
         '<meta charset="utf-8" />',
         "<title>Transcript</title>",
@@ -125,6 +125,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
         "</style>",
         "</head>",
         "<body>",
+        "<main>",
         f"<h2>{html.escape(transcript.file_name)}</h2>",
     ]
     for row in rows:
@@ -138,7 +139,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
             f"<div>{html.escape(row['text'])}</div>"
             "</div>"
         )
-    parts.extend(["</body>", "</html>"])
+    parts.extend(["</main>", "</body>", "</html>"])
     output_path.write_text("\n".join(parts), encoding="utf-8")
 
 


### PR DESCRIPTION
💡 What
Added `lang="en"` attributes and `<main>` tags to HTML documents generated by `transcription/exporters.py` and `features/steps/api_steps.py`.

🎯 Why
To improve accessibility for users leveraging screen readers. The `lang` attribute ensures the screen reader uses the correct pronunciation profile, and the `<main>` tag allows users to quickly navigate to the core content using landmark navigation.

📸 Before/After
Before: `<html><body><h2>...`
After: `<html lang="en"><body><main><h2>...`

♿ Accessibility
- `lang="en"` enables accurate screen reader pronunciation.
- `<main>` landmark enables rapid keyboard/screen reader navigation to the primary content area.

---
*PR created automatically by Jules for task [11165091112384300755](https://jules.google.com/task/11165091112384300755) started by @EffortlessSteven*