### PR TITLE
🎨 Palette: Add accessibility markup to HTML exports

### DIFF
--- a/transcription/exporters.py
+++ b/transcription/exporters.py
@@ -113,7 +113,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
     output_path.parent.mkdir(parents=True, exist_ok=True)
     parts: list[str] = [
         "<!doctype html>",
-        "<html>",
+        f'<html lang="{transcript.language or "en"}">',
         "<head>",
         '<meta charset="utf-8" />',
         "<title>Transcript</title>",
@@ -125,6 +125,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
         "</style>",
         "</head>",
         "<body>",
+        "<main>",
         f"<h2>{html.escape(transcript.file_name)}</h2>",
     ]
     for row in rows:
@@ -138,7 +139,7 @@ def export_html(transcript: Transcript, output_path: Path, unit: str = "segments
             f"<div>{html.escape(row['text'])}</div>"
             "</div>"
         )
-    parts.extend(["</body>", "</html>"])
+    parts.extend(["</main>", "</body>", "</html>"])
     output_path.write_text("\n".join(parts), encoding="utf-8")
 
 


### PR DESCRIPTION
💡 What: Added `lang` attribute to the `<html>` tag and wrapped the main content in a `<main>` landmark element in `export_html`.
🎯 Why: To improve screen reader accessibility and satisfy standard semantic HTML guidelines.
📸 Before/After: N/A (non-visual structural markup change)
♿ Accessibility: Improved screen reader support by specifying the document language and defining the primary landmark content region.

---
*PR created automatically by Jules for task [7737782235214052350](https://jules.google.com/task/7737782235214052350) started by @EffortlessSteven*