### PR TITLE
metadata: complete receipts at the JSON serialization seam

### DIFF
--- a/.github/workflows/finalize-surface-parity-620.yml
+++ b/.github/workflows/finalize-surface-parity-620.yml
@@ -1,0 +1,210 @@
+name: Finalize Surface Parity 620
+
+on:
+  push:
+    branches: [fix/surface-parity-620]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: finalize-surface-parity-620
+  cancel-in-progress: true
+
+jobs:
+  finalize:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout exact parity branch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: fix/surface-parity-620
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Make JSON serialization own idempotent receipt completion
+        run: |
+          python - <<'PY'
+          from __future__ import annotations
+
+          import ast
+          from pathlib import Path
+
+          path = Path("transcription/writers.py")
+          source = path.read_text(encoding="utf-8")
+          tree = ast.parse(source, filename=str(path))
+
+          import_line = (
+              "from .generation_receipt import ensure_generation_receipt\n"
+          )
+          if import_line not in source:
+              imports = [
+                  node
+                  for node in tree.body
+                  if isinstance(node, (ast.Import, ast.ImportFrom))
+              ]
+              assert imports, "writers.py has no import anchor"
+              insertion_line = max(node.end_lineno or node.lineno for node in imports)
+              lines = source.splitlines(keepends=True)
+              lines.insert(insertion_line, import_line)
+              source = "".join(lines)
+              tree = ast.parse(source, filename=str(path))
+
+          matches = [
+              node
+              for node in tree.body
+              if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+              and node.name == "write_json"
+          ]
+          assert len(matches) == 1, matches
+          function = matches[0]
+          assert function.args.args, "write_json has no transcript argument"
+          transcript_name = function.args.args[0].arg
+          statement = (
+              f"    {transcript_name}.meta = "
+              f"ensure_generation_receipt({transcript_name}.meta)\n"
+          )
+          if statement.strip() not in source:
+              insertion_line = function.body[0].lineno
+              if (
+                  isinstance(function.body[0], ast.Expr)
+                  and isinstance(function.body[0].value, ast.Constant)
+                  and isinstance(function.body[0].value.value, str)
+              ):
+                  insertion_line = (
+                      function.body[0].end_lineno or function.body[0].lineno
+                  ) + 1
+              lines = source.splitlines(keepends=True)
+              lines.insert(insertion_line - 1, statement)
+              source = "".join(lines)
+
+          ast.parse(source, filename=str(path))
+          path.write_text(source, encoding="utf-8")
+          PY
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install locked development environment
+        run: uv sync --frozen --python 3.12 --extra dev --extra api
+
+      - name: Apply and verify canonical formatting
+        run: |
+          uv run ruff check --fix \
+            transcription/generation_receipt.py \
+            transcription/writers.py \
+            tests/test_generation_receipt.py
+          uv run ruff format \
+            transcription/generation_receipt.py \
+            transcription/writers.py \
+            tests/test_generation_receipt.py
+          uv run ruff check \
+            transcription/generation_receipt.py \
+            transcription/writers.py \
+            tests/test_generation_receipt.py
+          uv run ruff format --check \
+            transcription/generation_receipt.py \
+            transcription/writers.py \
+            tests/test_generation_receipt.py
+          uv run mypy \
+            transcription/generation_receipt.py \
+            transcription/writers.py
+          git diff --check
+
+      - name: Verify parity and existing provenance/writer contracts
+        run: |
+          uv run pytest -q \
+            tests/test_generation_receipt.py \
+            tests/test_meta_utils.py \
+            tests/test_provenance_schema.py \
+            tests/test_provenance_surfaces.py \
+            tests/test_receipt.py \
+            tests/test_writers.py
+
+      - name: Verify full non-heavy repository suite
+        run: |
+          uv run pytest -q \
+            -m "not slow and not heavy and not requires_gpu" \
+            --no-cov
+
+      - name: Verify installed wheel outside checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          uv build --wheel
+          WHEEL=$(realpath "$(find dist -maxdepth 1 -name '*.whl' -print -quit)")
+          test -n "$WHEEL"
+          VENV="$RUNNER_TEMP/surface-parity-wheel"
+          uv venv "$VENV" --python 3.12
+          uv pip install --python "$VENV/bin/python" "${WHEEL}[api]"
+          uv pip install --python "$VENV/bin/python" jsonschema
+          uv pip check --python "$VENV/bin/python"
+          cd "$RUNNER_TEMP"
+          unset PYTHONPATH
+          "$VENV/bin/python" - <<'PY'
+          from __future__ import annotations
+
+          import json
+          from pathlib import Path
+
+          import transcription.generation_receipt as module
+          from transcription.models import Transcript
+          from transcription.writers import write_json
+
+          assert "site-packages" in Path(module.__file__).resolve().parts
+          transcript = Transcript(
+              file_name="clip.wav",
+              language="en",
+              segments=[],
+              meta={
+                  "generated_at": "2026-08-22T12:00:00Z",
+                  "audio_file": "clip.wav",
+                  "audio_duration_sec": 1.0,
+                  "model_name": "tiny",
+                  "device": "cpu",
+                  "compute_type": "int8",
+                  "beam_size": 5,
+                  "vad_min_silence_ms": 500,
+                  "language_hint": "en",
+                  "task": "transcribe",
+                  "pipeline_version": "2.0.2",
+                  "root": "/unrelated/caller",
+                  "asr_backend": "faster-whisper",
+                  "asr_device": "cpu",
+                  "asr_compute_type": "int8",
+              },
+          )
+          output = Path("clip.json")
+          write_json(transcript, output)
+          document = json.loads(output.read_text(encoding="utf-8"))
+          receipt = document["meta"]["receipt"]
+          assert receipt["model"] == "tiny"
+          assert receipt["device"] == "cpu"
+          assert receipt["compute_type"] == "int8"
+          assert "/unrelated/caller" not in json.dumps(receipt)
+          PY
+
+      - name: Remove one-shot workflow and commit accepted candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          rm .github/workflows/finalize-surface-parity-620.yml
+          git config user.name "EffortlessSteven"
+          git config user.email "git@effortlesssteven.com"
+          git add -A
+          git commit -m "metadata: complete receipts at the JSON serialization seam"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin HEAD:fix/surface-parity-620

--- a/.github/workflows/surface-parity-contract.yml
+++ b/.github/workflows/surface-parity-contract.yml
@@ -1,0 +1,202 @@
+name: Surface Parity Contract
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  surface-parity-contract:
+    name: surface-parity-contract (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install locked test environment
+        run: uv sync --frozen --python ${{ matrix.python-version }} --extra dev --extra api
+
+      - name: Verify static serialization contract
+        run: |
+          uv run ruff check \
+            transcription/generation_receipt.py \
+            transcription/writers.py \
+            tests/test_generation_receipt.py
+          uv run ruff format --check \
+            transcription/generation_receipt.py \
+            transcription/writers.py \
+            tests/test_generation_receipt.py
+          uv run mypy \
+            transcription/generation_receipt.py \
+            transcription/writers.py
+          git diff --check
+
+      - name: Verify canonical parity and existing provenance contracts
+        run: |
+          uv run pytest -q \
+            tests/test_generation_receipt.py \
+            tests/test_meta_utils.py \
+            tests/test_provenance_schema.py \
+            tests/test_provenance_surfaces.py \
+            tests/test_receipt.py \
+            tests/test_writers.py
+
+  surface-parity-full-suite:
+    name: surface-parity-full-suite (Python 3.12)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install locked development environment
+        run: uv sync --frozen --python 3.12 --extra dev --extra api
+
+      - name: Verify full non-heavy repository suite
+        run: |
+          uv run pytest -q \
+            -m "not slow and not heavy and not requires_gpu" \
+            --no-cov
+
+  surface-parity-installed:
+    name: surface-parity-installed (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Build and install wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          uv build --wheel
+          WHEEL=$(realpath "$(find dist -maxdepth 1 -name '*.whl' -print -quit)")
+          test -n "$WHEEL"
+          VENV="$RUNNER_TEMP/surface-parity-${{ matrix.python-version }}"
+          uv venv "$VENV" --python ${{ matrix.python-version }}
+          uv pip install --python "$VENV/bin/python" "${WHEEL}[api]"
+          uv pip install --python "$VENV/bin/python" jsonschema
+          uv pip check --python "$VENV/bin/python"
+          echo "SURFACE_PARITY_VENV=$VENV" >> "$GITHUB_ENV"
+
+      - name: Exercise installed writer outside checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP"
+          unset PYTHONPATH
+          "$SURFACE_PARITY_VENV/bin/python" - <<'PY'
+          from __future__ import annotations
+
+          import json
+          from pathlib import Path
+
+          import transcription.generation_receipt as module
+          from transcription.models import Transcript
+          from transcription.writers import write_json
+
+          assert "site-packages" in Path(module.__file__).resolve().parts
+          transcript = Transcript(
+              file_name="clip.wav",
+              language="en",
+              segments=[],
+              meta={
+                  "generated_at": "2026-08-22T12:00:00Z",
+                  "audio_file": "clip.wav",
+                  "audio_duration_sec": 1.0,
+                  "model_name": "tiny",
+                  "device": "cuda",
+                  "compute_type": "float16",
+                  "beam_size": 5,
+                  "vad_min_silence_ms": 500,
+                  "language_hint": "en",
+                  "task": "transcribe",
+                  "pipeline_version": "2.0.2",
+                  "root": "/unrelated/caller",
+                  "asr_backend": "faster-whisper",
+                  "asr_device": "cpu",
+                  "asr_compute_type": "int8",
+                  "asr_model_load_attempts": [
+                      {
+                          "device": "cuda",
+                          "compute_type": "float16",
+                          "outcome": "failed",
+                          "reason_code": "asr_model_load_failed",
+                          "private_error": "/private/provider/path",
+                      },
+                      {
+                          "device": "cpu",
+                          "compute_type": "int8",
+                          "outcome": "selected",
+                          "reason_code": "ok",
+                      },
+                  ],
+              },
+          )
+          output = Path("clip.json")
+          write_json(transcript, output)
+          document = json.loads(output.read_text(encoding="utf-8"))
+          receipt = document["meta"]["receipt"]
+          assert receipt["model"] == "tiny"
+          assert receipt["device"] == "cpu"
+          assert receipt["compute_type"] == "int8"
+          assert "/unrelated/caller" not in json.dumps(receipt)
+          assert "/private/provider/path" not in json.dumps(document)
+          PY

--- a/tests/test_generation_receipt.py
+++ b/tests/test_generation_receipt.py
@@ -1,0 +1,197 @@
+"""Canonical receipt attachment at the shared JSON serialization seam."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator, FormatChecker
+
+from transcription import _build_info
+from transcription.generation_receipt import ensure_generation_receipt
+from transcription.meta_utils import build_generation_metadata
+from transcription.models import Transcript
+from transcription.receipt import receipt_stable_projection
+from transcription.writers import write_json
+
+
+def legacy_generation_meta() -> dict:
+    return {
+        "generated_at": "2026-08-22T12:00:00Z",
+        "audio_file": "clip.wav",
+        "audio_duration_sec": 1.0,
+        "model_name": "tiny",
+        "device": "cuda",
+        "compute_type": "float16",
+        "beam_size": 5,
+        "vad_min_silence_ms": 500,
+        "language_hint": "en",
+        "task": "transcribe",
+        "pipeline_version": "2.0.2",
+        "root": "/private/caller/project",
+        "asr_backend": "faster-whisper",
+        "asr_model": "tiny",
+        "asr_device": "cpu",
+        "asr_compute_type": "int8",
+        "asr_model_load_attempts": [
+            {
+                "device": "cuda",
+                "compute_type": "float16",
+                "outcome": "failed",
+                "reason_code": "asr_model_load_failed",
+                "private_error": "/srv/private/model",
+            },
+            {
+                "device": "cpu",
+                "compute_type": "int8",
+                "outcome": "selected",
+                "reason_code": "ok",
+            },
+        ],
+    }
+
+
+def canonical_meta() -> dict:
+    transcript = Transcript(
+        file_name="clip.wav",
+        language="en",
+        segments=[],
+        meta={
+            "asr_backend": "faster-whisper",
+            "asr_model": "tiny",
+            "asr_device": "cpu",
+            "asr_compute_type": "int8",
+            "asr_model_load_attempts": legacy_generation_meta()[
+                "asr_model_load_attempts"
+            ],
+        },
+    )
+    return build_generation_metadata(
+        transcript,
+        duration_sec=1.0,
+        model_name="tiny",
+        config_device="cuda",
+        config_compute_type="float16",
+        beam_size=5,
+        vad_min_silence_ms=500,
+        language_hint="en",
+        task="transcribe",
+        pipeline_version="2.0.2",
+        root=Path("/private/caller/project"),
+    )
+
+
+def test_legacy_generation_metadata_receipt_matches_canonical_surface(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(_build_info, "SOURCE_COMMIT", "abcdef123456")
+    monkeypatch.setattr(_build_info, "BUILD_ID", "parity-620")
+
+    legacy = ensure_generation_receipt(legacy_generation_meta())
+    canonical = canonical_meta()
+
+    assert receipt_stable_projection(legacy["receipt"]) == receipt_stable_projection(
+        canonical["receipt"]
+    )
+    assert legacy["receipt"]["device"] == "cpu"
+    assert legacy["receipt"]["compute_type"] == "int8"
+    assert legacy["asr_model_load_attempts"] == legacy["receipt"][
+        "model_load_attempts"
+    ]
+    serialized = json.dumps(legacy)
+    assert "/srv/private/model" not in serialized
+    assert "/private/caller/project" not in json.dumps(legacy["receipt"])
+
+
+def test_incomplete_generation_metadata_remains_unknown() -> None:
+    incomplete = {
+        "model_name": "tiny",
+        "device": "cpu",
+        "compute_type": "int8",
+    }
+
+    assert ensure_generation_receipt(incomplete) == incomplete
+
+
+def test_existing_valid_receipt_is_preserved(monkeypatch) -> None:
+    monkeypatch.setattr(_build_info, "SOURCE_COMMIT", "abcdef123456")
+    meta = ensure_generation_receipt(legacy_generation_meta())
+    existing = dict(meta["receipt"])
+
+    second = ensure_generation_receipt(meta)
+
+    assert second["receipt"] == existing
+
+
+def test_existing_invalid_receipt_fails_closed() -> None:
+    with pytest.raises(ValueError, match="meta.receipt is invalid"):
+        ensure_generation_receipt({"receipt": {"model": "tiny"}})
+    with pytest.raises(ValueError, match="must be an object"):
+        ensure_generation_receipt({"receipt": "not-an-object"})
+
+
+def test_write_json_attaches_receipt_and_validates_complete_transcript(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(_build_info, "SOURCE_COMMIT", "abcdef123456")
+    monkeypatch.setattr(_build_info, "BUILD_ID", "parity-620")
+    transcript = Transcript(
+        file_name="clip.wav",
+        language="en",
+        segments=[],
+        meta=legacy_generation_meta(),
+    )
+    output = tmp_path / "clip.json"
+
+    write_json(transcript, output)
+
+    document = json.loads(output.read_text(encoding="utf-8"))
+    receipt = document["meta"]["receipt"]
+    assert receipt["git_commit"] == "abcdef123456"
+    assert receipt["build_id"] == "parity-620"
+    assert receipt["device"] == "cpu"
+    assert receipt["compute_type"] == "int8"
+    assert transcript.meta["receipt"] == receipt
+
+    package_root = resources.files("transcription")
+    receipt_schema = json.loads(
+        package_root.joinpath("schemas/receipt-v1.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    transcript_schema = json.loads(
+        package_root.joinpath("schemas/transcript-v2.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert not list(
+        Draft7Validator(
+            receipt_schema,
+            format_checker=FormatChecker(),
+        ).iter_errors(receipt)
+    )
+    assert not list(
+        Draft7Validator(
+            transcript_schema,
+            format_checker=FormatChecker(),
+        ).iter_errors(document)
+    )
+
+
+def test_write_json_leaves_non_generation_transcripts_unchanged(tmp_path: Path) -> None:
+    transcript = Transcript(
+        file_name="imported.wav",
+        language="en",
+        segments=[],
+        meta={"source": "imported"},
+    )
+    output = tmp_path / "imported.json"
+
+    write_json(transcript, output)
+
+    document = json.loads(output.read_text(encoding="utf-8"))
+    assert document["meta"] == {"source": "imported"}
+    assert transcript.meta == {"source": "imported"}

--- a/transcription/generation_receipt.py
+++ b/transcription/generation_receipt.py
@@ -1,0 +1,134 @@
+"""Idempotent receipt attachment for generation-complete transcript metadata.
+
+Direct file, bytes, and REST transcription attach the canonical receipt while
+building generation metadata. Older directory and CLI orchestration can reach
+the JSON writer with the same authoritative generation fields but no receipt.
+This module closes that serialization seam without guessing from incomplete
+metadata or consulting the caller's repository/environment.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .receipt import build_receipt, normalize_model_load_attempts, validate_receipt
+
+_GENERATION_FIELDS = frozenset(
+    {
+        "model_name",
+        "device",
+        "compute_type",
+        "beam_size",
+        "vad_min_silence_ms",
+        "task",
+    }
+)
+
+
+def _nonempty_string(*values: object, default: str | None = None) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return default
+
+
+def _created_at(meta: Mapping[str, Any]) -> str | None:
+    generated_at = meta.get("generated_at")
+    if isinstance(generated_at, str) and generated_at.strip():
+        return generated_at.strip()
+    return None
+
+
+def _attempts(
+    meta: Mapping[str, Any],
+    *,
+    device: str,
+    compute_type: str,
+) -> list[dict[str, str]]:
+    raw_attempts = meta.get("asr_model_load_attempts")
+    attempts = normalize_model_load_attempts(
+        raw_attempts
+        if isinstance(raw_attempts, Sequence)
+        and not isinstance(raw_attempts, str | bytes | bytearray)
+        else None
+    )
+    if attempts:
+        return attempts
+    return [
+        {
+            "device": device,
+            "compute_type": compute_type,
+            "outcome": "selected",
+            "reason_code": "ok",
+        }
+    ]
+
+
+def ensure_generation_receipt(
+    meta: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Return copied metadata with one canonical receipt when evidence is complete.
+
+    Existing receipts are validated and preserved byte-for-byte. Metadata that
+    does not contain every generation field used by the canonical config hash is
+    copied unchanged; unknown is preferable to a guessed provenance receipt.
+    """
+    copied = dict(meta or {})
+    existing = copied.get("receipt")
+    if existing is not None:
+        if not isinstance(existing, Mapping):
+            raise ValueError("meta.receipt must be an object")
+        errors = validate_receipt(existing)
+        if errors:
+            raise ValueError(f"meta.receipt is invalid: {'; '.join(errors)}")
+        copied["receipt"] = dict(existing)
+        return copied
+
+    if not _GENERATION_FIELDS.issubset(copied):
+        return copied
+
+    model = _nonempty_string(copied.get("asr_model"), copied.get("model_name"))
+    device = _nonempty_string(copied.get("asr_device"), copied.get("device"))
+    compute_type = _nonempty_string(
+        copied.get("asr_compute_type"),
+        copied.get("compute_type"),
+    )
+    if model is None or device is None or compute_type is None:
+        return copied
+
+    backend = _nonempty_string(
+        copied.get("asr_backend"),
+        default="faster-whisper",
+    )
+    model_revision = _nonempty_string(copied.get("asr_model_revision"))
+    attempts = _attempts(
+        copied,
+        device=device,
+        compute_type=compute_type,
+    )
+    receipt_config = {
+        "model": model,
+        "backend": backend,
+        "model_revision": model_revision,
+        "device": device,
+        "compute_type": compute_type,
+        "beam_size": copied["beam_size"],
+        "vad_min_silence_ms": copied["vad_min_silence_ms"],
+        "language_hint": copied.get("language_hint"),
+        "task": copied["task"],
+    }
+    receipt = build_receipt(
+        model=model,
+        backend=backend,
+        model_revision=model_revision,
+        device=device,
+        compute_type=compute_type,
+        model_load_attempts=attempts,
+        config=receipt_config,
+        created_at=_created_at(copied),
+    )
+    copied["receipt"] = receipt.to_dict()
+    if "asr_model_load_attempts" in copied:
+        copied["asr_model_load_attempts"] = [dict(attempt) for attempt in attempts]
+    return copied


### PR DESCRIPTION
## Ruling

File, bytes, and REST transcription already attach the canonical generation receipt through `build_generation_metadata()`. Older directory and CLI orchestration can reach the shared JSON writer with complete authoritative generation metadata but no `meta.receipt`.

This PR makes receipt completion an idempotent serialization responsibility **only when every field used by the canonical config hash is present**. Incomplete metadata remains unknown rather than being converted into guessed provenance.

Advances #620.

## What changes

- add `ensure_generation_receipt()` for generation-complete metadata;
- preserve and validate an existing canonical receipt;
- use actual `asr_*` model/device/compute evidence over configured values;
- preserve ordered bounded load attempts and remove private attempt fields;
- reuse `generated_at` as receipt creation time when present;
- attach the receipt immediately before shared JSON serialization;
- leave imported or otherwise incomplete transcripts unchanged;
- prove the stable receipt projection matches the direct canonical metadata path;
- validate the completed receipt and transcript against bundled schemas;
- prove the same transaction from the installed wheel outside the checkout.

## Review map

1. `transcription/generation_receipt.py` — evidence completeness, actual-runtime selection, idempotence, and fail-closed validation.
2. `transcription/writers.py` — one shared JSON serialization seam.
3. `tests/test_generation_receipt.py` — canonical parity, privacy, schema, idempotence, incomplete metadata, and writer behavior.
4. one-shot finalizer — patches the existing writer conservatively, runs focused and full non-heavy suites, verifies the installed wheel, then removes itself.

## Deliberate boundary

This PR does not manufacture receipts for incomplete imported transcripts, change segment content, normalize surface-specific file/root fields, or claim full CLI/directory parity without execution evidence. It closes the first concrete parity defect: complete generation evidence no longer loses its canonical receipt solely because it reached JSON through an older orchestration path.

## Acceptance

- [ ] direct canonical metadata and legacy complete metadata have equal stable receipt projections;
- [ ] actual selected runtime values outrank configured values;
- [ ] private provider paths are absent from receipt and retained attempt projection;
- [ ] existing valid receipts are preserved;
- [ ] invalid existing receipts fail closed;
- [ ] incomplete metadata remains unchanged;
- [ ] shared JSON serialization attaches the receipt;
- [ ] completed receipt and transcript validate against bundled schemas;
- [ ] existing provenance and writer tests pass;
- [ ] full non-heavy repository suite passes;
- [ ] installed wheel passes outside the checkout;
- [ ] temporary workflow is removed before merge.
