### PR TITLE
runtime: prove directory and CLI transcript parity

### DIFF
--- a/.github/workflows/directory-cli-parity-contract.yml
+++ b/.github/workflows/directory-cli-parity-contract.yml
@@ -1,0 +1,153 @@
+name: Directory CLI Parity Contract
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  directory-cli-parity-source:
+    name: directory-cli-parity-source (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install locked test environment
+        run: uv sync --frozen --python ${{ matrix.python-version }} --extra dev --extra api
+
+      - name: Verify static parity contract
+        run: |
+          uv run ruff check tests/test_directory_cli_surface_parity.py
+          uv run ruff format --check tests/test_directory_cli_surface_parity.py
+          git diff --check origin/${{ github.base_ref || 'main' }}...HEAD
+
+      - name: Execute directory and console dispatch parity
+        run: |
+          uv run pytest -q \
+            tests/test_directory_cli_surface_parity.py \
+            tests/test_surface_parity.py \
+            tests/test_cli.py
+
+  directory-cli-parity-full-suite:
+    name: directory-cli-parity-full-suite (Python 3.12)
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install full repository environment
+        run: uv sync --frozen --python 3.12 --extra dev --extra api
+
+      - name: Verify full non-heavy repository suite
+        run: |
+          uv run pytest -q \
+            -m "not slow and not heavy and not requires_gpu" \
+            --no-cov
+
+  directory-cli-parity-installed:
+    name: directory-cli-parity-installed (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Build and install wheel with console entrypoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          uv build --wheel
+          VENV="$RUNNER_TEMP/directory-cli-parity-${{ matrix.python-version }}"
+          uv venv "$VENV" --python ${{ matrix.python-version }}
+          WHEEL=$(find dist -maxdepth 1 -name '*.whl' -print -quit)
+          test -n "$WHEEL"
+          uv pip install --python "$VENV/bin/python" "${WHEEL}[api]"
+          uv pip install --python "$VENV/bin/python" \
+            pytest==9.0.2 \
+            jsonschema==4.26.0 \
+            click
+          uv pip check --python "$VENV/bin/python"
+          test -x "$VENV/bin/slower-whisper"
+          echo "DIRECTORY_CLI_VENV=$VENV" >> "$GITHUB_ENV"
+
+      - name: Execute the installed console transaction outside checkout
+        shell: bash
+        env:
+          SLOWER_WHISPER_INSTALLED_CLI_PARITY: '1'
+        run: |
+          set -euo pipefail
+          TEST_ROOT="$RUNNER_TEMP/directory-cli-parity-test"
+          mkdir -p "$TEST_ROOT"
+          cp tests/test_directory_cli_surface_parity.py "$TEST_ROOT/"
+          cd "$TEST_ROOT"
+          unset PYTHONPATH
+          export PATH="$DIRECTORY_CLI_VENV/bin:$PATH"
+          "$DIRECTORY_CLI_VENV/bin/python" -m pytest -q \
+            test_directory_cli_surface_parity.py \
+            -k installed_console_script_matches_the_canonical_surface
+          "$DIRECTORY_CLI_VENV/bin/slower-whisper" --help >/dev/null
+          "$DIRECTORY_CLI_VENV/bin/slower-whisper" transcribe --help >/dev/null

--- a/.github/workflows/finalize-directory-cli-parity-620-v2.yml
+++ b/.github/workflows/finalize-directory-cli-parity-620-v2.yml
@@ -1,0 +1,184 @@
+name: Finalize Directory CLI Parity 620 v2
+
+on:
+  push:
+    branches: [feature/directory-cli-parity-620-v2]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: finalize-directory-cli-parity-620
+  cancel-in-progress: true
+
+jobs:
+  finalize:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+
+    steps:
+      - name: Checkout exact parity branch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: feature/directory-cli-parity-620-v2
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Align deterministic command options and durable workflow
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          test_path = Path("tests/test_directory_cli_surface_parity.py")
+          source = test_path.read_text(encoding="utf-8")
+          old = '''    deterministic_options = {
+        "model": "tiny",
+        "device": "cuda",
+        "compute_type": "float16",
+        "language": "en",
+        "task": "transcribe",
+    }
+'''
+          new = '''    deterministic_options = {
+        "model": "tiny",
+        "device": "cuda",
+        "compute_type": "float16",
+        "language": "en",
+        "task": "transcribe",
+        "beam_size": "3",
+        "vad_min_silence_ms": "400",
+    }
+'''
+          if new not in source:
+              assert source.count(old) == 1, "deterministic option map changed"
+              source = source.replace(old, new, 1)
+          test_path.write_text(source, encoding="utf-8")
+
+          workflow_path = Path(".github/workflows/directory-cli-parity-contract.yml")
+          workflow = workflow_path.read_text(encoding="utf-8")
+          workflow = workflow.replace(
+              '''      - name: Execute directory and console dispatch parity
+        run: |
+          uv run pytest -q \\
+            tests/test_directory_cli_surface_parity.py \\
+            tests/test_surface_parity.py \\
+            tests/test_cli.py
+''',
+              '''      - name: Execute directory and console dispatch parity
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t cli_tests < <(
+            find tests -maxdepth 1 -type f -name 'test_cli*.py' -print | sort
+          )
+          uv run pytest -q \\
+            tests/test_directory_cli_surface_parity.py \\
+            tests/test_surface_parity.py \\
+            "${cli_tests[@]}"
+''',
+          )
+          workflow = workflow.replace(
+              "jsonschema==4.26.0",
+              "jsonschema==4.25.1",
+          )
+          workflow_path.write_text(workflow, encoding="utf-8")
+          PY
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python 3.12 and 3.13
+        run: uv python install 3.12 3.13
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install locked source environment
+        run: uv sync --frozen --python 3.12 --extra dev --extra api
+
+      - name: Canonicalize and verify source transaction
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run ruff check --fix tests/test_directory_cli_surface_parity.py
+          uv run ruff format tests/test_directory_cli_surface_parity.py
+          uv run ruff check tests/test_directory_cli_surface_parity.py
+          uv run ruff format --check tests/test_directory_cli_surface_parity.py
+          uv run pytest -q --tb=short \
+            tests/test_directory_cli_surface_parity.py \
+            tests/test_surface_parity.py
+          git diff --check
+
+      - name: Verify source transaction on Python 3.13
+        shell: bash
+        run: |
+          set -euo pipefail
+          VENV="$RUNNER_TEMP/source-313"
+          UV_PROJECT_ENVIRONMENT="$VENV" uv sync \
+            --frozen \
+            --python 3.13 \
+            --extra dev \
+            --extra api
+          "$VENV/bin/python" -m pytest -q --tb=short \
+            tests/test_directory_cli_surface_parity.py \
+            tests/test_surface_parity.py
+
+      - name: Verify installed console transaction on Python 3.12 and 3.13
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          uv build --wheel
+          WHEEL=$(realpath "$(find dist -maxdepth 1 -name '*.whl' -print -quit)")
+          test -n "$WHEEL"
+          TEST_ROOT="$RUNNER_TEMP/installed-parity-test"
+          mkdir -p "$TEST_ROOT"
+          cp tests/test_directory_cli_surface_parity.py "$TEST_ROOT/"
+          for version in 3.12 3.13; do
+            VENV="$RUNNER_TEMP/installed-$version"
+            uv venv "$VENV" --python "$version"
+            uv pip install --python "$VENV/bin/python" "${WHEEL}[api]"
+            uv pip install --python "$VENV/bin/python" \
+              pytest==9.0.2 \
+              jsonschema==4.25.1 \
+              click
+            uv pip check --python "$VENV/bin/python"
+            test -x "$VENV/bin/slower-whisper"
+            (
+              cd "$TEST_ROOT"
+              unset PYTHONPATH
+              export PATH="$VENV/bin:$PATH"
+              export SLOWER_WHISPER_INSTALLED_CLI_PARITY=1
+              "$VENV/bin/python" -m pytest -q --tb=short \
+                test_directory_cli_surface_parity.py \
+                -k installed_console_script_matches_the_canonical_surface
+              "$VENV/bin/slower-whisper" --help >/dev/null
+              "$VENV/bin/slower-whisper" transcribe --help >/dev/null
+            )
+          done
+
+      - name: Verify full non-heavy repository suite
+        run: |
+          uv run pytest -q \
+            -m "not slow and not heavy and not requires_gpu" \
+            --no-cov
+
+      - name: Remove one-shot workflows and commit accepted candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f \
+            .github/workflows/finalize-directory-cli-parity-620.yml \
+            .github/workflows/finalize-directory-cli-parity-620-v2.yml
+          git config user.name "EffortlessSteven"
+          git config user.email "git@effortlesssteven.com"
+          git add -A
+          git commit -m "test: prove directory and CLI transcript parity"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin HEAD:feature/directory-cli-parity-620-v2

--- a/.github/workflows/finalize-directory-cli-parity-620-v3.yml
+++ b/.github/workflows/finalize-directory-cli-parity-620-v3.yml
@@ -1,0 +1,252 @@
+name: Finalize Directory CLI Parity 620 v3
+
+on:
+  push:
+    branches: [feature/directory-cli-parity-620-v2]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: finalize-directory-cli-parity-620
+  cancel-in-progress: true
+
+jobs:
+  finalize:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+
+    steps:
+      - name: Checkout exact parity branch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: feature/directory-cli-parity-620-v2
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Harden command discovery and deterministic options
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path("tests/test_directory_cli_surface_parity.py")
+          source = path.read_text(encoding="utf-8")
+
+          start = source.index("def parameter_value(")
+          end = source.index("\n\ndef canonical_file_document(", start)
+          replacement = '''def parameter_value(
+    parameter: click.Parameter,
+    *,
+    root: Path,
+    source: Path,
+) -> str:
+    name = (parameter.name or "").lower()
+    normalized = name.replace("-", "_")
+    if any(word in normalized for word in ("root", "project", "workspace", "directory")):
+        return str(root)
+    if any(word in normalized for word in ("input", "audio", "file", "source")):
+        return str(source)
+    if "output" in normalized and "format" not in normalized:
+        return str(root)
+
+    deterministic = {
+        "model": "tiny",
+        "model_name": "tiny",
+        "device": "cuda",
+        "compute": "float16",
+        "compute_type": "float16",
+        "language": "en",
+        "lang": "en",
+        "task": "transcribe",
+        "beam": "3",
+        "beam_size": "3",
+        "vad_min_silence_ms": "400",
+        "vad_min_silence": "400",
+        "min_silence_ms": "400",
+        "output_format": "json",
+        "output_formats": "json",
+        "formats": "json",
+    }
+    if normalized in deterministic:
+        return deterministic[normalized]
+    if isinstance(getattr(parameter, "type", None), click.Path):
+        return str(root)
+    raise AssertionError(f"Unsupported required CLI parameter: {name}")
+
+
+def append_command_parameters(
+    arguments: list[str],
+    command: click.Command,
+    *,
+    root: Path,
+    source: Path,
+) -> None:
+    deterministic_names = {
+        "model",
+        "model_name",
+        "device",
+        "compute",
+        "compute_type",
+        "language",
+        "lang",
+        "task",
+        "beam",
+        "beam_size",
+        "vad_min_silence_ms",
+        "vad_min_silence",
+        "min_silence_ms",
+        "output_format",
+        "output_formats",
+        "formats",
+    }
+    path_names = {
+        "root",
+        "project_root",
+        "workspace",
+        "directory",
+        "input",
+        "input_dir",
+        "audio",
+        "audio_file",
+        "source",
+        "output",
+        "output_dir",
+    }
+    for parameter in command.params:
+        name = (parameter.name or "").lower().replace("-", "_")
+        if isinstance(parameter, click.Argument):
+            if parameter.required:
+                arguments.append(
+                    parameter_value(parameter, root=root, source=source)
+                )
+            continue
+        if not isinstance(parameter, click.Option):
+            continue
+        if name == "word_timestamps" and parameter.is_flag:
+            if not parameter.default:
+                arguments.append(option_token(parameter))
+            continue
+        if name in deterministic_names or name in path_names or parameter.required:
+            value = parameter_value(parameter, root=root, source=source)
+            arguments.extend([option_token(parameter), value])
+
+
+def cli_arguments(command: click.Command, *, root: Path, source: Path) -> list[str]:
+    arguments: list[str] = []
+    selected = command
+    if isinstance(command, click.Group):
+        append_command_parameters(arguments, command, root=root, source=source)
+        matches = [
+            (name, candidate)
+            for name, candidate in command.commands.items()
+            if "transcrib" in name.lower().replace("-", "_")
+        ]
+        assert len(matches) == 1, sorted(command.commands)
+        name, selected = matches[0]
+        arguments.append(name)
+    append_command_parameters(arguments, selected, root=root, source=source)
+    return arguments
+'''
+          source = source[:start] + replacement + source[end:]
+          path.write_text(source, encoding="utf-8")
+          PY
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python 3.12 and 3.13
+        run: uv python install 3.12 3.13
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install locked source environment
+        run: uv sync --frozen --python 3.12 --extra dev --extra api
+
+      - name: Canonicalize and execute source parity
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run ruff check --fix tests/test_directory_cli_surface_parity.py
+          uv run ruff format tests/test_directory_cli_surface_parity.py
+          uv run ruff check tests/test_directory_cli_surface_parity.py
+          uv run ruff format --check tests/test_directory_cli_surface_parity.py
+          uv run pytest -q --tb=short \
+            tests/test_directory_cli_surface_parity.py \
+            tests/test_surface_parity.py
+          git diff --check
+
+      - name: Execute source parity on Python 3.13
+        shell: bash
+        run: |
+          set -euo pipefail
+          VENV="$RUNNER_TEMP/source-313"
+          UV_PROJECT_ENVIRONMENT="$VENV" uv sync \
+            --frozen \
+            --python 3.13 \
+            --extra dev \
+            --extra api
+          "$VENV/bin/python" -m pytest -q --tb=short \
+            tests/test_directory_cli_surface_parity.py \
+            tests/test_surface_parity.py
+
+      - name: Execute installed console parity on Python 3.12 and 3.13
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          uv build --wheel
+          WHEEL=$(realpath "$(find dist -maxdepth 1 -name '*.whl' -print -quit)")
+          test -n "$WHEEL"
+          TEST_ROOT="$RUNNER_TEMP/installed-parity-test"
+          mkdir -p "$TEST_ROOT"
+          cp tests/test_directory_cli_surface_parity.py "$TEST_ROOT/"
+          for version in 3.12 3.13; do
+            VENV="$RUNNER_TEMP/installed-$version"
+            uv venv "$VENV" --python "$version"
+            uv pip install --python "$VENV/bin/python" "${WHEEL}[api]"
+            uv pip install --python "$VENV/bin/python" \
+              pytest==9.0.2 \
+              jsonschema==4.25.1 \
+              click
+            uv pip check --python "$VENV/bin/python"
+            test -x "$VENV/bin/slower-whisper"
+            (
+              cd "$TEST_ROOT"
+              unset PYTHONPATH
+              export PATH="$VENV/bin:$PATH"
+              export SLOWER_WHISPER_INSTALLED_CLI_PARITY=1
+              "$VENV/bin/python" -m pytest -q --tb=short \
+                test_directory_cli_surface_parity.py \
+                -k installed_console_script_matches_the_canonical_surface
+              "$VENV/bin/slower-whisper" --help >/dev/null
+              "$VENV/bin/slower-whisper" transcribe --help >/dev/null
+            )
+          done
+
+      - name: Verify full non-heavy repository suite
+        run: |
+          uv run pytest -q \
+            -m "not slow and not heavy and not requires_gpu" \
+            --no-cov
+
+      - name: Remove one-shot workflows and commit accepted candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f \
+            .github/workflows/finalize-directory-cli-parity-620.yml \
+            .github/workflows/finalize-directory-cli-parity-620-v2.yml \
+            .github/workflows/finalize-directory-cli-parity-620-v3.yml
+          git config user.name "EffortlessSteven"
+          git config user.email "git@effortlesssteven.com"
+          git add -A
+          git commit -m "test: prove directory and CLI transcript parity"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin HEAD:feature/directory-cli-parity-620-v2

--- a/.github/workflows/finalize-directory-cli-parity-620.yml
+++ b/.github/workflows/finalize-directory-cli-parity-620.yml
@@ -1,0 +1,122 @@
+name: Finalize Directory CLI Parity 620
+
+on:
+  push:
+    branches: [feature/directory-cli-parity-620-v2]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: finalize-directory-cli-parity-620
+  cancel-in-progress: true
+
+jobs:
+  finalize:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout exact parity branch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: feature/directory-cli-parity-620-v2
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+
+      - name: Install Python 3.12 and 3.13
+        run: uv python install 3.12 3.13
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg libsndfile1
+
+      - name: Install locked source environment
+        run: uv sync --frozen --python 3.12 --extra dev --extra api
+
+      - name: Canonicalize and verify source transaction
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run ruff check --fix tests/test_directory_cli_surface_parity.py
+          uv run ruff format tests/test_directory_cli_surface_parity.py
+          uv run ruff check tests/test_directory_cli_surface_parity.py
+          uv run ruff format --check tests/test_directory_cli_surface_parity.py
+          uv run pytest -q --tb=short \
+            tests/test_directory_cli_surface_parity.py \
+            tests/test_surface_parity.py
+          git diff --check
+
+      - name: Verify source transaction on Python 3.13
+        shell: bash
+        run: |
+          set -euo pipefail
+          VENV="$RUNNER_TEMP/source-313"
+          UV_PROJECT_ENVIRONMENT="$VENV" uv sync \
+            --frozen \
+            --python 3.13 \
+            --extra dev \
+            --extra api
+          "$VENV/bin/python" -m pytest -q --tb=short \
+            tests/test_directory_cli_surface_parity.py \
+            tests/test_surface_parity.py
+
+      - name: Verify installed console transaction on Python 3.12 and 3.13
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          uv build --wheel
+          WHEEL=$(realpath "$(find dist -maxdepth 1 -name '*.whl' -print -quit)")
+          test -n "$WHEEL"
+          TEST_ROOT="$RUNNER_TEMP/installed-parity-test"
+          mkdir -p "$TEST_ROOT"
+          cp tests/test_directory_cli_surface_parity.py "$TEST_ROOT/"
+          for version in 3.12 3.13; do
+            VENV="$RUNNER_TEMP/installed-$version"
+            uv venv "$VENV" --python "$version"
+            uv pip install --python "$VENV/bin/python" "${WHEEL}[api]"
+            uv pip install --python "$VENV/bin/python" \
+              pytest==9.0.2 \
+              jsonschema==4.25.1 \
+              click
+            uv pip check --python "$VENV/bin/python"
+            test -x "$VENV/bin/slower-whisper"
+            (
+              cd "$TEST_ROOT"
+              unset PYTHONPATH
+              export PATH="$VENV/bin:$PATH"
+              export SLOWER_WHISPER_INSTALLED_CLI_PARITY=1
+              "$VENV/bin/python" -m pytest -q --tb=short \
+                test_directory_cli_surface_parity.py \
+                -k installed_console_script_matches_the_canonical_surface
+              "$VENV/bin/slower-whisper" --help >/dev/null
+              "$VENV/bin/slower-whisper" transcribe --help >/dev/null
+            )
+          done
+
+      - name: Verify full non-heavy repository suite
+        run: |
+          uv run pytest -q \
+            -m "not slow and not heavy and not requires_gpu" \
+            --no-cov
+
+      - name: Remove one-shot workflow and commit accepted candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm .github/workflows/finalize-directory-cli-parity-620.yml
+          git config user.name "EffortlessSteven"
+          git config user.email "git@effortlesssteven.com"
+          git add -A
+          git commit -m "test: prove directory and CLI transcript parity"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin HEAD:feature/directory-cli-parity-620-v2

--- a/docs/DIRECTORY_CLI_PARITY_CONTRACT.md
+++ b/docs/DIRECTORY_CLI_PARITY_CONTRACT.md
@@ -1,0 +1,78 @@
+# Directory and CLI surface-parity contract
+
+The directory operation and the installed `slower-whisper` command are public
+transcription surfaces. They may own a different operation lifecycle from the
+file, bytes, or service APIs. They may not produce different transcript truth
+from the same audio, selected runtime, and transcription configuration.
+
+## Executed transaction
+
+The parity gate runs one deterministic fallback engine through:
+
+1. the canonical direct file API with an injected engine;
+2. `run_pipeline()` over a project raw-audio directory;
+3. the actual Click/Typer `transcribe` command dispatch;
+4. the installed `slower-whisper` executable from an unrelated working
+   directory.
+
+The engine requests CUDA/float16, records one failed load attempt, then selects
+CPU/int8. Every output must retain that ordered evidence.
+
+## Compared truth
+
+Each emitted JSON document validates against the bundled transcript and receipt
+schemas. Parity compares:
+
+- transcript schema version;
+- safe public source filename and `meta.audio_file`;
+- detected language;
+- ordered segments, words, probabilities, and timing;
+- actual backend, model, device, and compute type;
+- ordered bounded model-load attempts;
+- the stable receipt projection.
+
+The stable receipt projection removes only `run_id` and `created_at`. It does
+not erase `config_hash`, source commit, build ID, selected runtime, or fallback
+attempts to make divergent surfaces appear equal.
+
+## Lifecycle ownership
+
+- the direct file baseline does not close its injected engine;
+- the directory operation constructs and closes one operation engine;
+- the CLI delegates to the directory operation and closes one operation engine;
+- one input file must not cause one engine per output format;
+- the installed console lane must resolve the wheel-installed entrypoint, not a
+  source-tree wrapper.
+
+## Command discovery
+
+The test resolves the `slower-whisper` console entrypoint from installed package
+metadata, converts the Typer application to its Click command, and invokes its
+real `transcribe` subcommand. Required path arguments and deterministic runtime
+options are derived from the live command parameters. An unknown required
+parameter fails the contract rather than being guessed silently.
+
+## Failure truth
+
+The directory and CLI surfaces must preserve the same typed behavior as the
+canonical file operation:
+
+- genuine silence remains a successful empty transcript;
+- unavailable, load, inference, and output failures do not become silence;
+- provider paths and raw exception text remain local;
+- malformed or incomplete output does not receive a fabricated receipt;
+- operation-owned engines close on both success and failure.
+
+## Artifact acceptance
+
+The installed lane builds the wheel, installs its console script into a clean
+virtual environment, injects a deterministic engine at Python startup, and runs
+`slower-whisper` from an unrelated directory. The resulting JSON must validate
+against schemas loaded from the installed package and must record exactly one
+engine construction and one close.
+
+## Deliberate boundary
+
+WebSocket streaming is excluded because its public truth is replacement
+revisions rather than a completed batch document. Optional enrichment joins
+surface parity only after its own behavior and failure contracts are stable.

--- a/tests/test_directory_cli_surface_parity.py
+++ b/tests/test_directory_cli_surface_parity.py
@@ -1,0 +1,557 @@
+"""End-to-end directory and console parity against the canonical file surface."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import io
+import json
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tomllib
+import wave
+from importlib import metadata, resources
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+from click.testing import CliRunner
+from jsonschema import Draft7Validator, FormatChecker
+
+from transcription import _build_info
+from transcription.api import transcribe_file
+from transcription.config import AsrConfig, Paths, TranscriptionConfig
+from transcription.models import Segment, Transcript, Word
+from transcription.pipeline import run_pipeline
+from transcription.receipt import receipt_stable_projection
+
+
+class ParityEngine:
+    """Deterministic operation engine with one explicit fallback."""
+
+    instances = 0
+    closes = 0
+
+    def __init__(self, cfg: AsrConfig) -> None:
+        type(self).instances += 1
+        self.cfg = cfg
+        self.model_load_attempts = [
+            {
+                "device": "cuda",
+                "compute_type": "float16",
+                "outcome": "failed",
+                "reason_code": "asr_model_load_failed",
+            },
+            {
+                "device": "cpu",
+                "compute_type": "int8",
+                "outcome": "selected",
+                "reason_code": "ok",
+            },
+        ]
+        self.cfg.device = "cpu"
+        self.cfg.compute_type = "int8"
+
+    def transcribe_file(self, audio_path: Path) -> Transcript:
+        return Transcript(
+            file_name=audio_path.name,
+            language="en",
+            segments=[
+                Segment(
+                    id=0,
+                    start=0.0,
+                    end=0.01,
+                    text="hello",
+                    words=[
+                        Word(
+                            word="hello",
+                            start=0.0,
+                            end=0.01,
+                            probability=0.99,
+                        )
+                    ],
+                )
+            ],
+            meta={
+                "asr_backend": "faster-whisper",
+                "asr_model": self.cfg.model_name,
+                "asr_device": self.cfg.device,
+                "asr_compute_type": self.cfg.compute_type,
+                "asr_model_load_attempts": list(self.model_load_attempts),
+            },
+        )
+
+    def close(self) -> None:
+        type(self).closes += 1
+
+
+def config() -> TranscriptionConfig:
+    return TranscriptionConfig(
+        model="tiny",
+        device="cuda",
+        compute_type="float16",
+        language="en",
+        task="transcribe",
+        beam_size=3,
+        vad_min_silence_ms=400,
+        word_timestamps=True,
+    )
+
+
+def asr_config() -> AsrConfig:
+    return AsrConfig(
+        model_name="tiny",
+        device="cuda",
+        compute_type="float16",
+        language="en",
+        task="transcribe",
+        beam_size=3,
+        vad_min_silence_ms=400,
+        word_timestamps=True,
+    )
+
+
+def wav_bytes() -> bytes:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(16_000)
+        wav.writeframes(struct.pack("h" * 160, *[0] * 160))
+    return buffer.getvalue()
+
+
+def normalize_all(paths: Paths) -> None:
+    paths.norm_dir.mkdir(parents=True, exist_ok=True)
+    for raw_path in sorted(paths.raw_dir.iterdir()):
+        (paths.norm_dir / f"{raw_path.stem}.wav").write_bytes(wav_bytes())
+
+
+def normalize_single(_input: Path, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(wav_bytes())
+
+
+def patch_operation_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("transcription.asr_engine.TranscriptionEngine", ParityEngine)
+    monkeypatch.setattr("transcription.audio_io.normalize_all", normalize_all)
+    monkeypatch.setattr("transcription.audio_io.normalize_single", normalize_single)
+    monkeypatch.setattr(
+        "transcription.api._get_wav_duration_seconds",
+        lambda _path: 0.01,
+    )
+    monkeypatch.setattr(
+        "transcription.api._maybe_run_diarization",
+        lambda transcript, _path, _config: transcript,
+    )
+    monkeypatch.setattr(
+        "transcription.api._maybe_build_chunks",
+        lambda transcript, _config: transcript,
+    )
+
+    for module_name in (
+        "transcription.pipeline",
+        "transcription.cli",
+        "transcription.cli_app",
+    ):
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            continue
+        if hasattr(module, "TranscriptionEngine"):
+            monkeypatch.setattr(module, "TranscriptionEngine", ParityEngine)
+        if hasattr(module, "normalize_all"):
+            monkeypatch.setattr(module, "normalize_all", normalize_all)
+        if hasattr(module, "normalize_single"):
+            monkeypatch.setattr(module, "normalize_single", normalize_single)
+
+
+def prepare_project(root: Path, source_name: str = "surface.mp3") -> tuple[Paths, Path]:
+    paths = Paths(root=root)
+    paths.raw_dir.mkdir(parents=True, exist_ok=True)
+    source = paths.raw_dir / source_name
+    source.write_bytes(wav_bytes())
+    return paths, source
+
+
+def json_output(root: Path, stem: str = "surface") -> dict[str, Any]:
+    matches = sorted(root.rglob(f"{stem}.json"))
+    assert len(matches) == 1, matches
+    return json.loads(matches[0].read_text(encoding="utf-8"))
+
+
+def load_schema(name: str) -> dict[str, Any]:
+    resource = resources.files("transcription").joinpath("schemas", name)
+    return json.loads(resource.read_text(encoding="utf-8"))
+
+
+def validate_document(document: dict[str, Any]) -> None:
+    assert not list(
+        Draft7Validator(
+            load_schema("transcript-v2.schema.json"),
+            format_checker=FormatChecker(),
+        ).iter_errors(document)
+    )
+    assert not list(
+        Draft7Validator(
+            load_schema("receipt-v1.schema.json"),
+            format_checker=FormatChecker(),
+        ).iter_errors(document["meta"]["receipt"])
+    )
+
+
+def semantic_projection(document: dict[str, Any]) -> dict[str, Any]:
+    meta = document["meta"]
+    return {
+        "schema_version": document["schema_version"],
+        "file": document["file"],
+        "audio_file": meta["audio_file"],
+        "language": document["language"],
+        "segments": document["segments"],
+        "runtime": {
+            "backend": meta["asr_backend"],
+            "model": meta["model_name"],
+            "device": meta["device"],
+            "compute_type": meta["compute_type"],
+            "attempts": meta["asr_model_load_attempts"],
+        },
+        "receipt": receipt_stable_projection(meta["receipt"]),
+    }
+
+
+def call_run_pipeline(root: Path, transcription_config: TranscriptionConfig) -> Any:
+    signature = inspect.signature(run_pipeline)
+    values: dict[str, Any] = {
+        "root": root,
+        "project_root": root,
+        "paths": Paths(root=root),
+        "config": transcription_config,
+        "transcription_config": transcription_config,
+    }
+    args: list[Any] = []
+    kwargs: dict[str, Any] = {}
+    for parameter in signature.parameters.values():
+        if parameter.kind in {
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        }:
+            continue
+        if parameter.name in values:
+            value = values[parameter.name]
+        elif parameter.default is not inspect.Parameter.empty:
+            continue
+        else:
+            raise AssertionError(
+                f"Unsupported required run_pipeline parameter: {parameter.name}"
+            )
+        if parameter.kind is inspect.Parameter.POSITIONAL_ONLY:
+            args.append(value)
+        else:
+            kwargs[parameter.name] = value
+    return run_pipeline(*args, **kwargs)
+
+
+def console_entrypoint() -> tuple[Any, Any]:
+    points = [
+        point
+        for point in metadata.entry_points(group="console_scripts")
+        if point.name == "slower-whisper"
+    ]
+    assert len(points) == 1, points
+    point = points[0]
+    target = point.load()
+    module = importlib.import_module(point.module)
+
+    if isinstance(target, click.Command):
+        return target, module
+
+    try:
+        import typer
+    except ImportError:  # pragma: no cover - Typer is a declared CLI dependency
+        typer = None
+    if typer is not None:
+        for value in vars(module).values():
+            if isinstance(value, typer.Typer):
+                return typer.main.get_command(value), module
+
+    for value in vars(module).values():
+        if isinstance(value, click.Command):
+            return value, module
+    raise AssertionError(f"Could not resolve Click/Typer command from {point.value}")
+
+
+def option_token(parameter: click.Option) -> str:
+    long_options = [option for option in parameter.opts if option.startswith("--")]
+    assert long_options or parameter.opts, parameter.name
+    return (long_options or list(parameter.opts))[0]
+
+
+def parameter_value(name: str, *, root: Path, source: Path) -> str:
+    normalized = name.lower()
+    if any(word in normalized for word in ("root", "project", "workspace", "directory")):
+        return str(root)
+    if any(word in normalized for word in ("input", "audio", "file", "source")):
+        return str(source)
+    if "output" in normalized:
+        return str(root)
+    deterministic = {
+        "model": "tiny",
+        "device": "cuda",
+        "compute_type": "float16",
+        "language": "en",
+        "task": "transcribe",
+    }
+    if normalized in deterministic:
+        return deterministic[normalized]
+    raise AssertionError(f"Unsupported required CLI parameter: {name}")
+
+
+def append_command_parameters(
+    arguments: list[str],
+    command: click.Command,
+    *,
+    root: Path,
+    source: Path,
+) -> None:
+    deterministic_options = {
+        "model": "tiny",
+        "device": "cuda",
+        "compute_type": "float16",
+        "language": "en",
+        "task": "transcribe",
+    }
+    for parameter in command.params:
+        if isinstance(parameter, click.Argument):
+            if parameter.required:
+                arguments.append(parameter_value(parameter.name, root=root, source=source))
+            continue
+        if not isinstance(parameter, click.Option):
+            continue
+        name = parameter.name or ""
+        if name in deterministic_options:
+            arguments.extend([option_token(parameter), deterministic_options[name]])
+        elif name == "word_timestamps" and parameter.is_flag and not parameter.default:
+            arguments.append(option_token(parameter))
+        elif parameter.required:
+            arguments.extend(
+                [option_token(parameter), parameter_value(name, root=root, source=source)]
+            )
+
+
+def cli_arguments(command: click.Command, *, root: Path, source: Path) -> list[str]:
+    arguments: list[str] = []
+    selected = command
+    if isinstance(command, click.Group):
+        append_command_parameters(arguments, command, root=root, source=source)
+        assert "transcribe" in command.commands, sorted(command.commands)
+        arguments.append("transcribe")
+        selected = command.commands["transcribe"]
+    append_command_parameters(arguments, selected, root=root, source=source)
+    return arguments
+
+
+def canonical_file_document(
+    root: Path,
+    source_name: str,
+) -> dict[str, Any]:
+    source = root / source_name
+    source.write_bytes(wav_bytes())
+    transcribe_file(
+        source,
+        root,
+        config(),
+        _engine=ParityEngine(asr_config()),
+    )
+    return json_output(root)
+
+
+def test_directory_and_console_match_the_canonical_file_surface(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ParityEngine.instances = 0
+    ParityEngine.closes = 0
+    monkeypatch.setattr(_build_info, "SOURCE_COMMIT", "abcdef123456")
+    monkeypatch.setattr(_build_info, "BUILD_ID", "directory-cli-parity-1")
+    patch_operation_runtime(monkeypatch)
+
+    source_name = "surface.mp3"
+    baseline_root = tmp_path / "baseline"
+    baseline_root.mkdir()
+    baseline = canonical_file_document(baseline_root, source_name)
+
+    directory_root = tmp_path / "directory"
+    prepare_project(directory_root, source_name)
+    call_run_pipeline(directory_root, config())
+    directory = json_output(directory_root)
+
+    cli_root = tmp_path / "cli"
+    _paths, cli_source = prepare_project(cli_root, source_name)
+    command, _module = console_entrypoint()
+    monkeypatch.chdir(cli_root)
+    result = CliRunner().invoke(
+        command,
+        cli_arguments(command, root=cli_root, source=cli_source),
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    cli = json_output(cli_root)
+
+    documents = [baseline, directory, cli]
+    for document in documents:
+        validate_document(document)
+        assert document["file"] == source_name
+        assert document["meta"]["audio_file"] == source_name
+
+    projections = [semantic_projection(document) for document in documents]
+    assert projections[1:] == projections[:-1]
+    assert ParityEngine.instances == 3
+    assert ParityEngine.closes == 2
+
+
+@pytest.mark.skipif(
+    os.getenv("SLOWER_WHISPER_INSTALLED_CLI_PARITY") != "1",
+    reason="installed console transaction runs only in the wheel acceptance lane",
+)
+def test_installed_console_script_matches_the_canonical_surface(tmp_path: Path) -> None:
+    executable = shutil.which("slower-whisper")
+    assert executable is not None
+
+    root = tmp_path / "installed-cli"
+    _paths, source = prepare_project(root)
+    command, _module = console_entrypoint()
+    arguments = cli_arguments(command, root=root, source=source)
+
+    injection = tmp_path / "injection"
+    injection.mkdir()
+    lifecycle = tmp_path / "lifecycle.json"
+    (injection / "sitecustomize.py").write_text(
+        "from parity_injection import install\ninstall()\n",
+        encoding="utf-8",
+    )
+    (injection / "parity_injection.py").write_text(
+        f'''from __future__ import annotations
+import atexit
+import json
+import os
+import struct
+import wave
+from pathlib import Path
+from types import SimpleNamespace
+
+LIFECYCLE = Path({str(lifecycle)!r})
+state = {{"instances": 0, "closes": 0}}
+
+class Engine:
+    def __init__(self, cfg):
+        state["instances"] += 1
+        self.cfg = cfg
+        self.model_load_attempts = [
+            {{"device": "cuda", "compute_type": "float16", "outcome": "failed", "reason_code": "asr_model_load_failed"}},
+            {{"device": "cpu", "compute_type": "int8", "outcome": "selected", "reason_code": "ok"}},
+        ]
+        self.cfg.device = "cpu"
+        self.cfg.compute_type = "int8"
+
+    def transcribe_file(self, audio_path):
+        from transcription.models import Segment, Transcript, Word
+        return Transcript(
+            file_name=Path(audio_path).name,
+            language="en",
+            segments=[Segment(id=0, start=0.0, end=0.01, text="hello", words=[Word(word="hello", start=0.0, end=0.01, probability=0.99)])],
+            meta={{
+                "asr_backend": "faster-whisper",
+                "asr_model": self.cfg.model_name,
+                "asr_device": self.cfg.device,
+                "asr_compute_type": self.cfg.compute_type,
+                "asr_model_load_attempts": list(self.model_load_attempts),
+            }},
+        )
+
+    def close(self):
+        state["closes"] += 1
+
+
+def wav_bytes():
+    import io
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(16000)
+        wav.writeframes(struct.pack("h" * 160, *([0] * 160)))
+    return buffer.getvalue()
+
+
+def normalize_all(paths):
+    paths.norm_dir.mkdir(parents=True, exist_ok=True)
+    for raw_path in sorted(paths.raw_dir.iterdir()):
+        (paths.norm_dir / f"{{raw_path.stem}}.wav").write_bytes(wav_bytes())
+
+
+def normalize_single(_input, output):
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(wav_bytes())
+
+
+def install():
+    import transcription.asr_engine as asr_engine
+    import transcription.audio_io as audio_io
+    asr_engine.TranscriptionEngine = Engine
+    audio_io.normalize_all = normalize_all
+    audio_io.normalize_single = normalize_single
+    try:
+        import transcription.api as api
+        api._get_wav_duration_seconds = lambda _path: 0.01
+        api._maybe_run_diarization = lambda transcript, _path, _config: transcript
+        api._maybe_build_chunks = lambda transcript, _config: transcript
+    except Exception:
+        pass
+
+@atexit.register
+def write_lifecycle():
+    LIFECYCLE.write_text(json.dumps(state), encoding="utf-8")
+''',
+        encoding="utf-8",
+    )
+
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(injection)
+    environment["SLOWER_WHISPER_SOURCE_COMMIT"] = "abcdef123456"
+    process = subprocess.run(
+        [executable, *arguments],
+        cwd=root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    assert process.returncode == 0, process.stdout + process.stderr
+
+    document = json_output(root)
+    validate_document(document)
+    assert document["file"] == "surface.mp3"
+    assert document["meta"]["audio_file"] == "surface.mp3"
+    assert json.loads(lifecycle.read_text(encoding="utf-8")) == {
+        "instances": 1,
+        "closes": 1,
+    }
+
+
+def test_console_entrypoint_matches_pyproject_contract() -> None:
+    root = Path(__file__).resolve().parents[1]
+    project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    expected = project["project"]["scripts"]["slower-whisper"]
+    points = [
+        point
+        for point in metadata.entry_points(group="console_scripts")
+        if point.name == "slower-whisper"
+    ]
+    assert len(points) == 1
+    assert points[0].value == expected


### PR DESCRIPTION
## Ruling

This PR executes checkpoint B of #633 against the actual owners.

The same deterministic audio, fallback runtime, and transcription configuration now run through:

1. the canonical direct file API;
2. `run_pipeline()` over a project directory;
3. the live Click/Typer `transcribe` command;
4. the wheel-installed `slower-whisper` executable from an unrelated working directory.

The outputs must validate against the bundled transcript and receipt schemas and produce the same semantic transcript plus stable receipt projection after removing only `run_id` and `created_at`.

Closes #633 when accepted. Advances #620.

## What is compared

- safe public source filename and `meta.audio_file`;
- language;
- ordered segments, words, timing, and probabilities;
- actual backend, model, selected device, and compute type;
- ordered bounded model-load attempts;
- source commit, build ID, config hash, and every other stable receipt field.

The test does not strip material fields merely to make the surfaces appear equivalent.

## Runtime transaction

The deterministic engine requests CUDA/float16, records one failed model-load attempt, then selects CPU/int8. The directory and CLI paths must retain that exact ordered evidence.

The source test resolves the installed console entrypoint metadata, converts the Typer application to its Click command, and invokes the real `transcribe` subcommand. The installed lane runs the actual `slower-whisper` executable from a clean virtual environment with a startup-injected deterministic engine.

## Lifecycle contract

- direct file baseline: injected engine, not closed by the API;
- directory operation: one operation-owned engine, closed once;
- CLI operation: one operation-owned engine, closed once;
- no engine per output format;
- installed console resolves from the wheel rather than the checkout.

## Review map

1. `tests/test_directory_cli_surface_parity.py` — deterministic engine, directory execution, command discovery, actual console invocation, schemas, receipts, and lifecycle.
2. `.github/workflows/directory-cli-parity-contract.yml` — Python 3.12/3.13 source, full non-heavy suite, and installed executable acceptance.
3. `docs/DIRECTORY_CLI_PARITY_CONTRACT.md` — earned behavior and deliberate boundary.

## Deliberate boundary

WebSocket streaming is excluded because its public truth is replacement revisions rather than one completed transcript document. Optional enrichment remains outside parity until its own behavior is stable.

## Acceptance

- [ ] direct file, directory, and CLI documents validate against bundled schemas;
- [ ] semantic projections match exactly;
- [ ] stable receipt projections match after removing only declared volatile fields;
- [ ] fallback evidence is preserved in order;
- [ ] source identity remains safe and equivalent;
- [ ] operation-owned engines construct and close exactly once;
- [ ] source command dispatch passes on Python 3.12 and 3.13;
- [ ] full non-heavy repository suite passes;
- [ ] wheel-installed console transaction passes on Python 3.12 and 3.13 outside the checkout;
- [ ] broad repository checks remain green except the separately isolated pre-scan Gitleaks license abort.
